### PR TITLE
fix: merging ignore policies with same id

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -155,6 +155,7 @@ function mergePath(type, into, pathRoot, rootPolicy, policy) {
   if (!rootPolicy[into]) {
     rootPolicy[into] = {};
   }
+
   Object.keys(policy[type]).forEach(function (id) {
     // convert the path from `module@version` to `parent > module@version`
     policy[type][id] = policy[type][id].map(function (path) {
@@ -174,7 +175,7 @@ function mergePath(type, into, pathRoot, rootPolicy, policy) {
     }
 
     // otherwise we need to merge up manually
-    rootPolicy[into][id] = rootPolicy[type][id].concat(policy[type][id]);
+    rootPolicy[into][id] = rootPolicy[into][id].concat(policy[type][id]);
   });
 }
 

--- a/test/fixtures/ignore-duped/.snyk
+++ b/test/fixtures/ignore-duped/.snyk
@@ -1,0 +1,6 @@
+ignore:
+  'npm:hawk:20160119':
+    - 'sqlite > node-pre-gyp > request > hawk':
+        reason: hawk got bumped
+        expires: '2116-03-01T14:30:04.136Z'
+version: v1

--- a/test/fixtures/ignore-duped/package.json
+++ b/test/fixtures/ignore-duped/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ignore",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "snyk": "*",
+    "sqlite": "0.0.2"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "snyk test && echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/test/fixtures/ignore/.snyk
+++ b/test/fixtures/ignore/.snyk
@@ -1,14 +1,15 @@
 ignore:
   'npm:hawk:20160119':
-    - 'sqlite > sqlite3 > node-pre-gyp > request > hawk':
+    - sqlite > sqlite3 > node-pre-gyp > request > hawk:
         reason: hawk got bumped
         expires: '2116-03-01T14:30:04.136Z'
   'npm:is-my-json-valid:20160118':
-    - 'sqlite > sqlite3 > node-pre-gyp > request > har-validator > is-my-json-valid':
+    - sqlite > sqlite3 > node-pre-gyp > request > har-validator > is-my-json-valid:
         reason: dev tool
         expires: '2116-03-01T14:30:04.136Z'
   'npm:tar:20151103':
-    - 'sqlite > sqlite3 > node-pre-gyp > tar-pack > tar':
+    - sqlite > sqlite3 > node-pre-gyp > tar-pack > tar:
         reason: none given
         expires: '2116-03-01T14:30:04.137Z'
+patch: {}
 version: v1

--- a/test/functional/SC-1084.test.js
+++ b/test/functional/SC-1084.test.js
@@ -1,0 +1,11 @@
+var test = require('tap-only');
+var policy = require('../../');
+var fixtures = __dirname + '/../fixtures';
+var dir1 = fixtures + '/ignore';
+var dir2 = fixtures + '/ignore-duped';
+
+test('multiple policies merge when the vuln id is the same in ignore', function (t) {
+  return policy.load(['.', dir1, dir2], { loose: true }).then(function (res) {
+    t.equal(res.suggest['npm:hawk:20160119'].length, 2, 'hawk is ignored in two places');
+  });
+});

--- a/test/unit/policy-save.test.js
+++ b/test/unit/policy-save.test.js
@@ -20,8 +20,8 @@ test('policy.save', function (t) {
   var asText = '';
   return fs.readFile(filename, 'utf8')
     .then(function (res) {
-      asText = res;
-      return res;
+      asText = res.trim();
+      return asText;
     })
     .then(policy.loadFromText)
     .then(function (res) {
@@ -30,6 +30,7 @@ test('policy.save', function (t) {
     .then(function () {
       t.equal(writeSpy.callCount, 1, 'write only once');
       t.equal(writeSpy.args[0][0], filename, 'filename correct');
-      t.equal(writeSpy.args[0][1].indexOf(asText), 0, 'body contains original');
+      var parsed = writeSpy.args[0][1].trim();
+      t.equal(parsed, asText, 'body contains original');
     });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by @grnd 

#### What does this PR do?

Fixes the issue where two ignore rules with the same vuln.id cause an exception. 

#### Where should the reviewer start?

`lib/index.js` - have included inline comment to explain change.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/SC-1084