### PR TITLE
feat: return information about why vulns were filtered

### DIFF
--- a/lib/filter/ignore.js
+++ b/lib/filter/ignore.js
@@ -30,8 +30,8 @@ function filterIgnored(ignore, vuln, filtered) {
     // vulnerability is ignored. if none of the rules match, then let we'll
     // keep it.
 
-    // if rules.some, then ignore vuln
-    var res = ignore[vuln.id].some(function (rule) {
+    // if rules.find, then ignore vuln
+    var res = ignore[vuln.id].find(function (rule) {
       var path = Object.keys(rule)[0]; // this is a string
       var expires = rule[path].expires;
 
@@ -53,7 +53,7 @@ function filterIgnored(ignore, vuln, filtered) {
     });
 
     if (res) {
-      vuln.ignore = ignore[vuln.id];
+      vuln.ignore = res[Object.keys(res)[0]];
       filtered.push(vuln);
     }
 

--- a/lib/filter/ignore.js
+++ b/lib/filter/ignore.js
@@ -53,6 +53,7 @@ function filterIgnored(ignore, vuln, filtered) {
     });
 
     if (res) {
+      vuln.ignore = ignore[vuln.id];
       filtered.push(vuln);
     }
 

--- a/lib/filter/ignore.js
+++ b/lib/filter/ignore.js
@@ -31,7 +31,7 @@ function filterIgnored(ignore, vuln, filtered) {
     // keep it.
 
     // if rules.find, then ignore vuln
-    var res = ignore[vuln.id].find(function (rule) {
+    var appliedRules = ignore[vuln.id].filter(function (rule) {
       var path = Object.keys(rule)[0]; // this is a string
       var expires = rule[path].expires;
 
@@ -52,11 +52,15 @@ function filterIgnored(ignore, vuln, filtered) {
       return false;
     });
 
-    if (res) {
-      vuln.ignore = res[Object.keys(res)[0]];
+    if (appliedRules.length) {
+      vuln.filtered = {
+        ignored: appliedRules.map(function (rule) {
+          return rule[Object.keys(rule)[0]];
+        }),
+      };
       filtered.push(vuln);
     }
 
-    return res ? false : vuln;
+    return appliedRules.length ? false : vuln;
   }).filter(Boolean);
 }

--- a/lib/filter/patch.js
+++ b/lib/filter/patch.js
@@ -73,6 +73,7 @@ function filterPatched(patched, vuln, cwd, skipVerifyPatch, filteredPatches) {
     });
 
     if (res) {
+      vuln.patch = patched[vuln.id];
       filteredPatches.push(vuln);
     }
 

--- a/lib/filter/patch.js
+++ b/lib/filter/patch.js
@@ -7,9 +7,9 @@ var statSync = require('fs').statSync;
 var getVulnSource = require('./get-vuln-source');
 
 // cwd is used for testing
-function filterPatched(patched, vuln, cwd, skipVerifyPatch, filteredPatches) {
+function filterPatched(patched, vulns, cwd, skipVerifyPatch, filteredPatches) {
   if (!patched) {
-    return vuln;
+    return vulns;
   }
 
   if (!filteredPatches) {
@@ -18,7 +18,7 @@ function filterPatched(patched, vuln, cwd, skipVerifyPatch, filteredPatches) {
 
 
   debug('filtering patched');
-  return vuln.map(function (vuln) {
+  return vulns.map(function (vuln) {
     if (!patched[vuln.id]) {
       return vuln;
     }
@@ -31,7 +31,7 @@ function filterPatched(patched, vuln, cwd, skipVerifyPatch, filteredPatches) {
     // keep it.
 
     // if rules.find, then ignore vuln
-    var filtered = patched[vuln.id].map(function (rule) {
+    var vulnRules = patched[vuln.id].map(function (rule) {
 
       // first check if the path is a match on the rule
       var pathMatch = matchToRule(vuln, rule);
@@ -40,24 +40,24 @@ function filterPatched(patched, vuln, cwd, skipVerifyPatch, filteredPatches) {
         var path = Object.keys(rule)[0]; // this is a string
         debug('(patch) ignoring based on path match: %s ~= %s', path,
           vuln.from.slice(1).join(' > '));
-        return { vuln: vuln, rule: rule };
+        return rule;
       }
 
       return false;
     }).filter(Boolean);
 
     // run through the potential rules to check if there's a patch flag in place
-    var res = filtered.find(function (item) {
+    var appliedRules = vulnRules.filter(function () {
       // the target directory where our module name will live
       if (skipVerifyPatch) {
         return true;
       }
 
-      var source = getVulnSource(item.vuln, cwd, true);
+      var source = getVulnSource(vuln, cwd, true);
 
-      var id = item.vuln.id.replace(/:/g, '-');
+      var id = vuln.id.replace(/:/g, '-');
       var flag = path.resolve(source, '.snyk-' + id + '.flag');
-      var oldFlag = path.resolve(source, '.snyk-' + item.vuln.id + '.flag');
+      var oldFlag = path.resolve(source, '.snyk-' + vuln.id + '.flag');
       var res = false;
       try {
         res = statSync(flag);
@@ -67,18 +67,20 @@ function filterPatched(patched, vuln, cwd, skipVerifyPatch, filteredPatches) {
         } catch (e) {}
       }
 
-      debug('flag found for %s? %s', item.vuln.id);
+      debug('flag found for %s? %s', vuln.id);
 
       return !!res;
     });
 
-    res = res && res.rule;
-
-    if (res) {
-      vuln.patch = res[Object.keys(res)[0]];
+    if (appliedRules.length) {
+      vuln.filtered = {
+        patches: appliedRules.map(function (rule) {
+          return rule[Object.keys(rule)[0]];
+        }),
+      };
       filteredPatches.push(vuln);
     }
 
-    return res ? false : vuln;
+    return appliedRules.length ? false : vuln;
   }).filter(Boolean);
 }

--- a/lib/filter/patch.js
+++ b/lib/filter/patch.js
@@ -30,7 +30,7 @@ function filterPatched(patched, vuln, cwd, skipVerifyPatch, filteredPatches) {
     // vulnerability is ignored. if none of the rules match, then let we'll
     // keep it.
 
-    // if rules.some, then ignore vuln
+    // if rules.find, then ignore vuln
     var filtered = patched[vuln.id].map(function (rule) {
 
       // first check if the path is a match on the rule
@@ -40,24 +40,24 @@ function filterPatched(patched, vuln, cwd, skipVerifyPatch, filteredPatches) {
         var path = Object.keys(rule)[0]; // this is a string
         debug('(patch) ignoring based on path match: %s ~= %s', path,
           vuln.from.slice(1).join(' > '));
-        return vuln;
+        return { vuln: vuln, rule: rule };
       }
 
       return false;
     }).filter(Boolean);
 
     // run through the potential rules to check if there's a patch flag in place
-    var res = filtered.some(function (vuln) {
+    var res = filtered.find(function (item) {
       // the target directory where our module name will live
       if (skipVerifyPatch) {
         return true;
       }
 
-      var source = getVulnSource(vuln, cwd, true);
+      var source = getVulnSource(item.vuln, cwd, true);
 
-      var id = vuln.id.replace(/:/g, '-');
+      var id = item.vuln.id.replace(/:/g, '-');
       var flag = path.resolve(source, '.snyk-' + id + '.flag');
-      var oldFlag = path.resolve(source, '.snyk-' + vuln.id + '.flag');
+      var oldFlag = path.resolve(source, '.snyk-' + item.vuln.id + '.flag');
       var res = false;
       try {
         res = statSync(flag);
@@ -67,13 +67,15 @@ function filterPatched(patched, vuln, cwd, skipVerifyPatch, filteredPatches) {
         } catch (e) {}
       }
 
-      debug('flag found for %s? %s', vuln.id);
+      debug('flag found for %s? %s', item.vuln.id);
 
       return !!res;
     });
 
+    res = res && res.rule;
+
     if (res) {
-      vuln.patch = patched[vuln.id];
+      vuln.patch = res[Object.keys(res)[0]];
       filteredPatches.push(vuln);
     }
 

--- a/test/unit/filter-ignore.test.js
+++ b/test/unit/filter-ignore.test.js
@@ -11,13 +11,18 @@ test('ignored vulns do not turn up in tests', function (t) {
     var start = vulns.vulnerabilities.length;
     t.ok(vulns.vulnerabilities.length > 0, 'we have vulns to start with');
 
+    var filtered = [];
+
     vulns.vulnerabilities = ignore(
       config.ignore,
-      vulns.vulnerabilities
+      vulns.vulnerabilities,
+      filtered
     );
 
     // should strip 3
 
     t.equal(start - 3, vulns.vulnerabilities.length, 'post filter: ' + vulns.vulnerabilities.length);
+    t.equal(3, filtered.length, filtered.length + ' vulns filtered');
+    t.ok(filtered[0].ignore, 'filtered vuln has ignore info');
   }).catch(t.threw).then(t.end);
 });

--- a/test/unit/filter-ignore.test.js
+++ b/test/unit/filter-ignore.test.js
@@ -22,6 +22,21 @@ test('ignored vulns do not turn up in tests', function (t) {
     // should strip 3
     t.equal(start - 3, vulns.vulnerabilities.length, 'post filter: ' + vulns.vulnerabilities.length);
     t.equal(3, filtered.length, filtered.length + ' vulns filtered');
-    t.equal(filtered[0].ignore.reason, 'hawk got bumped', 'filtered vuln has ignore info');
-  }).catch(t.threw).then(t.end);
+    var expected = {
+      'npm:hawk:20160119': [{ reason: 'hawk got bumped', expires: '2116-03-01T14:30:04.136Z' }],
+      'npm:is-my-json-valid:20160118': [{ reason: 'dev tool', expires: '2116-03-01T14:30:04.136Z' }],
+      'npm:tar:20151103': [{ reason: 'none given', expires: '2116-03-01T14:30:04.137Z' }],
+    };
+    var actual = filtered.reduce(
+      function (actual, vuln) {
+        actual[vuln.id] = vuln.filtered.ignored;
+        return actual;
+      },
+      {});
+    t.same(actual, expected, 'filtered vulns include ignore rules');
+
+    t.notEqual(vulns.vulnerabilities.every(function (vuln) {
+      return !!vuln.ignored;
+    }), 'vulns do not have ignored property');
+}).catch(t.threw).then(t.end);
 });

--- a/test/unit/filter-ignore.test.js
+++ b/test/unit/filter-ignore.test.js
@@ -20,9 +20,8 @@ test('ignored vulns do not turn up in tests', function (t) {
     );
 
     // should strip 3
-
     t.equal(start - 3, vulns.vulnerabilities.length, 'post filter: ' + vulns.vulnerabilities.length);
     t.equal(3, filtered.length, filtered.length + ' vulns filtered');
-    t.ok(filtered[0].ignore, 'filtered vuln has ignore info');
+    t.equal(filtered[0].ignore.reason, 'hawk got bumped', 'filtered vuln has ignore info');
   }).catch(t.threw).then(t.end);
 });

--- a/test/unit/filter-patch.test.js
+++ b/test/unit/filter-patch.test.js
@@ -29,14 +29,20 @@ test('patched vulns do not turn up in tests', function (t) {
     var start = vulns.vulnerabilities.length;
     t.ok(vulns.vulnerabilities.length > 0, 'we have vulns to start with');
 
+    var filtered = [];
+
     vulns.vulnerabilities = patch(
       config.patch,
       vulns.vulnerabilities,
-      fixtures
+      fixtures,
+      true,
+      filtered
     );
 
     // should strip 2
 
     t.equal(start - 2, vulns.vulnerabilities.length, 'post filter');
+    t.equal(2, filtered.length, filtered.length + ' vulns filtered');
+    t.ok(filtered[0].patch, 'filtered vuln has patch info');
   }).catch(t.threw).then(t.end);
 });

--- a/test/unit/filter-patch.test.js
+++ b/test/unit/filter-patch.test.js
@@ -43,6 +43,20 @@ test('patched vulns do not turn up in tests', function (t) {
 
     t.equal(start - 2, vulns.vulnerabilities.length, 'post filter');
     t.equal(2, filtered.length, filtered.length + ' vulns filtered');
-    t.ok(filtered[0].patch, 'filtered vuln has patch info');
+
+    var expected = {
+      'npm:uglify-js:20150824': [{ patched: '2016-03-03T18:06:06.091Z' }],
+      'npm:uglify-js:20151024': [{ patched: '2016-03-03T18:06:06.091Z' }],
+    };
+    var actual = filtered.reduce(
+      function (actual, vuln) {
+        actual[vuln.id] = vuln.filtered.patches;
+        return actual;
+      }, {});
+    t.same(actual, expected, 'filtered vulns include patch rules');
+
+    t.notEqual(vulns.vulnerabilities.every(function (vuln) {
+      return !!vuln.patches;
+    }), 'vulns do not have patches property');
   }).catch(t.threw).then(t.end);
 });


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by @gjvis (Snyk internal team)

#### What does this PR do?

Returns information about filtered vulns from the `filter` method.

This is a non breaking change as filtered vulns were already returned as an array at `vulns.filtered`. But now each vuln that was filtered will contain a key `ignore` if the policy file states that it should be ignored, and `patch` if the policy file states that it was patched.

The value of the `ignore` key is as follows:
```javascript
[
  {
    'sqlite > sqlite3 > node-pre-gyp > request > hawk': {
      reason: 'hawk got bumped',
      expires: '2116-03-01T14:30:04.136Z'
    }
  }
]
```

This means that the vuln was ignored at the path `sqlite > sqlite3 > node-pre-gyp > request > hawk`.

The value of the `patch` key is as follows:
```javascript
[
  {
    'jade > transformers > uglify-js': {
      patched: '2016-03-03T18:06:06.091Z'
    }
  }
]
```

This means that the vuln was patched at the path `jade > transformers > uglify-js`.

#### Where should the reviewer start?

Take a look at `filter-ignore-test.js` and `filter-patch-test.js`

#### How should this be manually tested?

Try loading a policy file that contains some `ignore` and `patch` rules. When you run `filter`, you will get back an object with a ket of `filtered`, which will now contain information on why each vuln was filtered.

#### Any background context you want to provide?

This is required for displaying ignored and patched vulnerabilities in the UI

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/SC-2257

#### Screenshots


#### Additional questions

