### PR TITLE
fix: make parser.import handle invalid inputs

### DIFF
--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -17,7 +17,7 @@ var parsers = {
 function imports(rawYaml) {
   var data = yaml.safeLoad(rawYaml || '');
 
-  if (!data) {
+  if (!data || typeof data !== 'object') {
     data = {};
   }
 

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -15,6 +15,18 @@ test('parser fills out defaults', function (t) {
   t.end();
 });
 
+test('parser fills out defaults for invalid inputs', function (t) {
+  var res = parser.import('test');
+  var expect = {
+    version: 'v1.0.0',
+    ignore: {},
+    patch: {},
+  };
+
+  t.deepEqual(res, expect, 'parser fills defaults for invalid inputs');
+  t.end();
+});
+
 test('parser does not modify default parsed format', function (t) {
   var expect = {
     version: 'v1.0.0',


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by @gjvis  (Snyk internal team)

#### What does this PR do?

Handles invalid inputs to `policy.import` which would get parsed by `yaml.safeLoad` into a `string` or `number`. We only support `object`s for our policy files.

If an invalid input is provided, we handle it the same way for no input provided (return a blank policy definition)

#### Where should the reviewer start?

```bash
tap test/unit/parser.test.js
```

#### How should this be manually tested?

Try calling `parser. loadFromText('test')` or `parser. loadFromText('1')`. Expect the following response:

```javascript
{
    version: 'v1.0.0',
    ignore: {},
    patch: {},
}
```

#### Any background context you want to provide?

https://sentry.io/snyk/phoenix_prod/issues/171767999/

#### What are the relevant tickets?


#### Screenshots


#### Additional questions

