### PR TITLE
feat: add comments to policy files

### DIFF
--- a/lib/parser/add-comments.js
+++ b/lib/parser/add-comments.js
@@ -1,0 +1,23 @@
+module.exports = addComments;
+
+var initialComment = '# Snyk (https://snyk.io) policy file, patches or ' +
+                     'ignores known vulnerabilities.';
+var inlineComments = {
+  ignore: '# ignores vulnerabilities until expiry date; change duration by ' +
+          'modifying expiry date',
+  patch: '# patches apply the minimum changes required to fix a vulnerability',
+};
+
+function addComments(policyExport) {
+  var lines = policyExport.split('\n');
+  lines.unshift(initialComment);
+
+  Object.keys(inlineComments).forEach(function (key) {
+    var position = lines.indexOf(key + ':');
+    if (position !== -1) {
+      lines.splice(position, 0, inlineComments[key]);
+    }
+  });
+
+  return lines.join('\n');
+}

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -2,6 +2,7 @@ var path = require('path');
 var cloneDeep = require('lodash.clonedeep');
 var semver = require('semver');
 var yaml = require('js-yaml');
+var addComments = require('./add-comments');
 
 module.exports = {
   import: imports,
@@ -59,7 +60,8 @@ function exports(policy) {
 
   // ensure we always update the version of the policy format
   data.version = version();
-  return yaml.safeDump(data);
+  // put inline comments into the exported yaml file
+  return addComments(yaml.safeDump(data));
 }
 
 function version() {

--- a/test/fixtures/ignore/.snyk
+++ b/test/fixtures/ignore/.snyk
@@ -1,3 +1,5 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:hawk:20160119':
     - sqlite > sqlite3 > node-pre-gyp > request > hawk:

--- a/test/unit/parser-add-comments.test.js
+++ b/test/unit/parser-add-comments.test.js
@@ -1,0 +1,89 @@
+var test = require('tap-only');
+var addComments = require('../../lib/parser/add-comments');
+var yaml = require('js-yaml');
+
+test('policy with no patches or ignores', function (t) {
+  var res = addComments(yaml.safeDump({
+    version: 'v1.0.0',
+    patch: {},
+    ignore: {},
+  }));
+
+  t.ok(res.match(/^# Snyk \(https:\/\/snyk\.io\) policy file/),
+    'addComments adds initial comment');
+  t.notMatch(res, '# patches apply the minimum changes required to fix ' +
+    'a vulnerability\npatch:', 'addComments does not add patch comment');
+  t.notMatch(res, '# ignores vulnerabilities until expiry date; change ' +
+    'duration by modifying expiry date\nignore:',
+    'addComments does not add ignore comment');
+  t.end();
+});
+
+test('policy with patches', function (t) {
+  var res = addComments(yaml.safeDump({
+    version: 'v1.0.0',
+    patch: {
+      'glue > hapi > joi > moment': [
+        {
+          patched: '2016-02-26T16:19:06.050Z',
+        },
+      ],
+    },
+    ignore: {},
+  }));
+
+  t.match(res, '# patches apply the minimum changes required to fix ' +
+    'a vulnerability\npatch:', 'addComments adds patch comment');
+  t.notMatch(res, '# ignores vulnerabilities until expiry date; change ' +
+    'duration by modifying expiry date\nignore:',
+    'addComments does not add ignore comment');
+  t.end();
+});
+
+test('policy with ignores', function (t) {
+  var res = addComments(yaml.safeDump({
+    version: 'v1.0.0',
+    patch: {},
+    ignore: {
+      'glue > hapi > joi > moment': [
+        {
+          patched: '2016-02-26T16:19:06.050Z',
+        },
+      ],
+    },
+  }));
+
+  t.match(res, '# ignores vulnerabilities until expiry date; change ' +
+    'duration by modifying expiry date\nignore:',
+    'addComments adds ignore comment');
+  t.notMatch(res, '# patches apply the minimum changes required to fix ' +
+    'a vulnerability\npatch:', 'addComments does not add patch comment');
+  t.end();
+});
+
+test('policy with ignores and patches', function (t) {
+  var res = addComments(yaml.safeDump({
+    version: 'v1.0.0',
+    patch: {
+      'glue > hapi > joi > moment': [
+        {
+          patched: '2016-02-26T16:19:06.050Z',
+        },
+      ],
+    },
+    ignore: {
+      'glue > hapi > joi > moment': [
+        {
+          patched: '2016-02-26T16:19:06.050Z',
+        },
+      ],
+    },
+  }));
+
+  t.match(res, '# ignores vulnerabilities until expiry date; change ' +
+    'duration by modifying expiry date\nignore:',
+    'addComments adds ignore comment');
+  t.match(res, '# patches apply the minimum changes required to fix ' +
+    'a vulnerability\npatch:', 'addComments adds patch comment');
+  t.end();
+});

--- a/test/unit/policy-save.test.js
+++ b/test/unit/policy-save.test.js
@@ -32,5 +32,7 @@ test('policy.save', function (t) {
       t.equal(writeSpy.args[0][0], filename, 'filename correct');
       var parsed = writeSpy.args[0][1].trim();
       t.equal(parsed, asText, 'body contains original');
+      t.match(parsed, '# Snyk (https://snyk.io) policy file, patches or ' +
+              'ignores known vulnerabilities.', 'body contains comments');
     });
 });


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Adds comments to policy files

E.g.

```yaml
# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
version: v1.6.1
# ignores vulnerabilities until expiry date; change duration by modifying expiry date
ignore:
  'npm:hawk:20160119':
    - sqlite > sqlite3 > node-pre-gyp > request > hawk:
        reason: hawk got bumped
        expires: '2116-03-01T14:30:04.136Z'
```

#### Where should the reviewer start?

`tap test/unit/policy-save.test.js`

#### How should this be manually tested?

- Go to any repo that has vulns and run `snyk wizard`
- Answer the questions so that a policy file is created/modified (patch or ignore some vulns)
- Ensure that the generated policy file contains comments inline

#### Any background context you want to provide?

This will help with onboarding new users who have never seen a Snyk policy file before and want to understand it's purpose

