### PR TITLE
fix: bump snyk-module to remove npmjs name validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "js-yaml": "^3.5.3",
     "lodash.clonedeep": "^4.3.1",
     "semver": "^5.1.0",
-    "snyk-module": "^1.6.0",
+    "snyk-module": "^1.8.1",
     "snyk-resolve": "^1.0.0",
     "snyk-try-require": "^1.1.1",
     "then-fs": "^2.0.0"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @

#### What does this PR do?

Bumps the `snyk-module` dependency to `^1.8.1`. This allows the policy to be applied to projects whose `name` does not conform to npmjs standards. This prevents projects from being published on npmjs.com, but nothing else. We encounter such projects quite often and want to be able to apply snyk policy on them.