### PR TITLE
fix: use isUpgradable, isPatchable booleans for disregardIfFixable

### DIFF
--- a/lib/filter/ignore.js
+++ b/lib/filter/ignore.js
@@ -44,7 +44,7 @@ function filterIgnored(ignore, vuln, filtered) {
       }
 
       if (pathMatch && rule[path].disregardIfFixable &&
-        (vuln.upgradePath.length || vuln.patches.length)) {
+        (vuln.isUpgradable || vuln.isPatchable)) {
         debug('%s vuln is fixable and rule is set to disregard if fixable',
           vuln.id);
         return false;


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by @remy (Snyk internal team)

#### What does this PR do?

Instead of inferring upgradability & patchability, use the booleans `isUpgradable` and `isPatchable` which are the source of truth.

#### Where should the reviewer start?


#### How should this be manually tested?

Find an issue that is not upgradable or patchable (but may have an upgrade path regardless). 

Ignore the issue via the API/website with `disregardIfFixable` to true. Make sure that the issue is ignored.

#### Any background context you want to provide?

Sometimes there is an upgrade path that cannot be applied within the project. In this case there may be an upgrade path, but `isUpgradable` will still be false.
