### PR TITLE
feat: return path for ignored issues

### DIFF
--- a/lib/filter/ignore.js
+++ b/lib/filter/ignore.js
@@ -1,5 +1,6 @@
 module.exports = filterIgnored;
 
+var cloneDeep = require('lodash.clonedeep');
 var debug = require('debug')('snyk:policy');
 var matchToRule = require('../match').matchToRule;
 
@@ -62,7 +63,10 @@ function filterIgnored(ignore, vuln, filtered) {
     if (appliedRules.length) {
       vuln.filtered = {
         ignored: appliedRules.map(function (rule) {
-          return rule[Object.keys(rule)[0]];
+          var ignorePath = Object.keys(rule)[0];
+          var ruleData = cloneDeep(rule[ignorePath]);
+          ruleData.path = ignorePath.split(' > ');
+          return ruleData;
         }),
       };
       filtered.push(vuln);

--- a/test/unit/filter-ignore.test.js
+++ b/test/unit/filter-ignore.test.js
@@ -23,10 +23,37 @@ test('ignored vulns do not turn up in tests', function (t) {
     t.equal(start - 4, vulns.vulnerabilities.length, 'post filter: ' + vulns.vulnerabilities.length);
     t.equal(4, filtered.length, '4 vulns filtered');
     var expected = {
-      'npm:hawk:20160119': [{ reason: 'hawk got bumped', expires: '2116-03-01T14:30:04.136Z' }],
-      'npm:is-my-json-valid:20160118': [{ reason: 'dev tool', expires: '2116-03-01T14:30:04.136Z' }],
-      'npm:tar:20151103': [{ reason: 'none given', expires: '2116-03-01T14:30:04.137Z' }],
-      'npm:marked:20170907': [{ reason: 'none given', disregardIfFixable: true }],
+      'npm:hawk:20160119': [
+        {
+          reason: 'hawk got bumped',
+          expires: '2116-03-01T14:30:04.136Z',
+          path: ['sqlite', 'sqlite3', 'node-pre-gyp', 'request', 'hawk'],
+        },
+      ],
+      'npm:is-my-json-valid:20160118': [
+        {
+          reason: 'dev tool',
+          expires: '2116-03-01T14:30:04.136Z',
+          path: [
+            'sqlite', 'sqlite3', 'node-pre-gyp', 'request', 'har-validator',
+            'is-my-json-valid',
+          ],
+        },
+      ],
+      'npm:tar:20151103': [
+        {
+          reason: 'none given',
+          expires: '2116-03-01T14:30:04.137Z',
+          path: ['sqlite', 'sqlite3', 'node-pre-gyp', 'tar-pack', 'tar'],
+        },
+      ],
+      'npm:marked:20170907': [
+        {
+          reason: 'none given',
+          disregardIfFixable: true,
+          path: ['*'],
+        },
+      ],
     };
     var actual = filtered.reduce(
       function (actual, vuln) {


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by @remy (Snyk internal team)

#### What does this PR do?

Returns the original path that was matched when a vuln is filtered due to an ignore rule.

#### Where should the reviewer start?

```bash
tap test/unit/filter-ignore.test.js
```

#### How should this be manually tested?

Filter a list of vulns where one or more has an ignore policy that is applicative. Ensure that the `filtered` array contains the path(s) within the `vuln.filtered.ignored` array of applicative ignore rules.

#### Any background context you want to provide?

This is needed so that we can display the matched path within the reporting service. Currently this information is lost to us when we look at the `filtered` metadata of a `vuln`.
