### PR TITLE
fix: handle patch policies with no body

### DIFF
--- a/lib/filter/patch.js
+++ b/lib/filter/patch.js
@@ -77,7 +77,7 @@ function filterPatched(patched, vulns, cwd, skipVerifyPatch, filteredPatches) {
       vuln.filtered = {
         patches: appliedRules.map(function (rule) {
           var path = Object.keys(rule)[0];
-          var ruleData = cloneDeep(rule[path]);
+          var ruleData = cloneDeep(rule[path]) || {};
           ruleData.path = path.split(' > ');
           return ruleData;
         }),

--- a/lib/index.js
+++ b/lib/index.js
@@ -174,6 +174,7 @@ function mergePath(type, into, pathRoot, rootPolicy, policy) {
       var key = Object.keys(path).pop();
       var newPath = {};
       newPath[pathRoot + ' > ' + key] = path[key];
+      path[key] = path[key] || {};
       path[key].from = pathRoot;
       return newPath;
     });

--- a/test/fixtures/patch/.snyk
+++ b/test/fixtures/patch/.snyk
@@ -5,4 +5,6 @@ patch:
   'npm:uglify-js:20151024':
     - 'jade > transformers > uglify-js':
         patched: '2016-03-03T18:06:06.091Z'
+  'npm:semver:20150403':
+    - '*':
 version: v1

--- a/test/functional/load-multi.test.js
+++ b/test/functional/load-multi.test.js
@@ -7,6 +7,6 @@ var dir2 = fixtures + '/patch';
 test('multiple directories, one with policy, one without', function (t) {
   return policy.load([dir1, dir2], { loose: true }).then(function (res) {
     t.ok(res.patch, 'patch property is present');
-    t.equal(Object.keys(res.patch).length, 2, 'patches found');
+    t.equal(Object.keys(res.patch).length, 3, 'patches found');
   });
 });

--- a/test/unit/filter-patch.test.js
+++ b/test/unit/filter-patch.test.js
@@ -39,10 +39,11 @@ test('patched vulns do not turn up in tests', function (t) {
       filtered
     );
 
-    // should strip 2
 
-    t.equal(start - 2, vulns.vulnerabilities.length, 'post filter');
-    t.equal(2, filtered.length, filtered.length + ' vulns filtered');
+    // should strip 3
+
+    t.equal(start - 3, vulns.vulnerabilities.length, 'post filter');
+    t.equal(3, filtered.length, '3 vulns filtered');
 
     var expected = {
       'npm:uglify-js:20150824': [
@@ -57,6 +58,9 @@ test('patched vulns do not turn up in tests', function (t) {
           path: ['jade', 'transformers', 'uglify-js'],
         },
       ],
+      'npm:semver:20150403': [
+        { path: ['*'] }
+      ]
     };
     var actual = filtered.reduce(
       function (actual, vuln) {

--- a/test/unit/policy.test.js
+++ b/test/unit/policy.test.js
@@ -113,6 +113,7 @@ test('policy.load (multiple - ENOENT - loose)', function (t) {
     var ids = [
       'npm:uglify-js:20150824',
       'npm:uglify-js:20151024',
+      'npm:semver:20150403',
     ];
     t.deepEqual(Object.keys(res.patch), ids, 'policy loaded');
   });


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by @remy (Snyk internal team)

#### What does this PR do?

For some reason some of the patch policies have an empty body.

We should coerce this to an empty object so that we can state the original path that the patch was applied via.
