### PR TITLE
update email-validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "email-validator": "^1.1.1",
+    "email-validator": "^2.0.3",
     "es6-promise": "^3.1.2",
     "js-yaml": "^3.5.3",
     "lodash.clonedeep": "^4.3.1",


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by @remy (Snyk internal team)

#### What does this PR do?

~In order to maintain compatibility with Node 0.12, we need to pin `email-validator` to the version that supports this version of Node.~

There's a new major version release that we'd like to use. This new version requires Node>=4

