### PR TITLE
fix: remove broken patch from parsing result

### DIFF
--- a/lib/parser/v1.js
+++ b/lib/parser/v1.js
@@ -9,6 +9,12 @@ module.exports = function imports(policy) {
     policy.patch = {};
   }
 
+  Object.keys(policy.patch).forEach(function (id) {
+    if (!Array.isArray(policy.patch[id])) {
+      delete policy.patch[id];
+    }
+  });
+
   checkForOldFormat(policy.ignore); // this is only an old issue on ignores
   validate(policy.ignore);
   validate(policy.patch);
@@ -51,9 +57,6 @@ function validate(policy) {
 function needsFixing(policy) {
   var move = [];
   Object.keys(policy).forEach(function (id) {
-    if (!Array.isArray(policy[id])) {
-      return; // continue;
-    }
     policy[id].forEach(function (rule) {
       var keys = Object.keys(rule);
       keys.shift(); // drop the first

--- a/test/functional/BST-264.test.js
+++ b/test/functional/BST-264.test.js
@@ -1,0 +1,10 @@
+var test = require('tap-only');
+var policy = require('../../');
+
+test('broken patch should not be in output', function (t) {
+  return policy
+    .load(__dirname + '/../fixtures/issues/BST-264/missing-path-to-package.snyk', {loose: true})
+    .then(function (policy) {
+      t.deepEqual(policy.patch, {}, 'patch section is empty');
+    });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

#### What does this PR do?

Remove patch from parsing result if it's broken for one of vulns.

* This PR fixing previous one.


#### Any background context you want to provide?

https://github.com/snyk/policy/pull/25

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/BST-264