### PR TITLE
feat: support inline comments

### DIFF
--- a/lib/parser/add-comments.js
+++ b/lib/parser/add-comments.js
@@ -1,5 +1,7 @@
 module.exports = addComments;
 
+var inlineCommentPattern = new RegExp(/policyInlineComment:/, 'g');
+
 var initialComment = '# Snyk (https://snyk.io) policy file, patches or ' +
                      'ignores known vulnerabilities.';
 var inlineComments = {
@@ -19,5 +21,10 @@ function addComments(policyExport) {
     }
   });
 
-  return lines.join('\n');
+  return lines.map(line => {
+    if (inlineCommentPattern.test(line)) {
+      return line.replace(inlineCommentPattern, '#').replace(/\'|\"/g,'');
+    }
+    return line;
+  }).join('\n');
 }

--- a/test/unit/add.test.js
+++ b/test/unit/add.test.js
@@ -31,11 +31,14 @@ test('add errors without options', function (t) {
       id: 'a',
       path: 'a > b > c',
       expires: d2,
+      policyInlineComment: 'foo',
     });
 
     t.deepEqual(Object.keys(policy.patch), ['a'], '`a` is the only root');
     t.deepEqual(policy.patch.a.length, 2, 'two paths on `a`');
     t.deepEqual(policy.patch.a[1]['a > b > c'].expires, d2, 'metadata saved');
+    t.deepEqual(policy.patch.a[1]['a > b > c'].policyInlineComment, 'foo',
+      'correctly saves policyInlineComment');
   });
 });
 
@@ -47,14 +50,14 @@ test('add ignore with valid reasonType', function (t) {
       reasonType: 'wont-fix',
     });
   })
-  .then(function (policy) {
-    t.ok('error not thrown');
-    t.deepEqual(policy.ignore.a[0]['a > b'].reasonType, 'wont-fix',
-      'metadata saved');
-  })
-  .catch(function () {
-    t.fail('error thrown thrown');
-  });
+    .then(function (policy) {
+      t.ok('error not thrown');
+      t.deepEqual(policy.ignore.a[0]['a > b'].reasonType, 'wont-fix',
+        'metadata saved');
+    })
+    .catch(function () {
+      t.fail('error thrown thrown');
+    });
 });
 
 test('add ignore with invalid reasonType', function (t) {
@@ -65,13 +68,13 @@ test('add ignore with invalid reasonType', function (t) {
       reasonType: 'test',
     });
   })
-  .then(function () {
-    t.fail('error not thrown');
-  })
-  .catch(function (err) {
-    t.equal(err.message, 'invalid reasonType test',
-      'error is thrown');
-  });
+    .then(function () {
+      t.fail('error not thrown');
+    })
+    .catch(function (err) {
+      t.equal(err.message, 'invalid reasonType test',
+        'error is thrown');
+    });
 });
 
 test('add ignore with valid ignoredBy', function (t) {
@@ -86,14 +89,14 @@ test('add ignore with valid ignoredBy', function (t) {
       ignoredBy: ignoredBy,
     });
   })
-  .then(function (policy) {
-    t.ok('error not thrown');
-    t.deepEqual(policy.ignore.a[0]['a > b'].ignoredBy, ignoredBy,
-      'metadata saved');
-  })
-  .catch(function () {
-    t.fail('error thrown thrown');
-  });
+    .then(function (policy) {
+      t.ok('error not thrown');
+      t.deepEqual(policy.ignore.a[0]['a > b'].ignoredBy, ignoredBy,
+        'metadata saved');
+    })
+    .catch(function () {
+      t.fail('error thrown thrown');
+    });
 });
 
 test('add ignore with invalid ignoredBy', function (t) {
@@ -108,11 +111,11 @@ test('add ignore with invalid ignoredBy', function (t) {
       ignoredBy: ignoredBy,
     });
   })
-  .then(function () {
-    t.fail('error not thrown');
-  })
-  .catch(function (err) {
-    t.equal(err.message, 'ignoredBy.email must be a valid email address',
-      'error is thrown');
-  });
+    .then(function () {
+      t.fail('error not thrown');
+    })
+    .catch(function (err) {
+      t.equal(err.message, 'ignoredBy.email must be a valid email address',
+        'error is thrown');
+    });
 });

--- a/test/unit/parser-add-comments.test.js
+++ b/test/unit/parser-add-comments.test.js
@@ -26,6 +26,7 @@ test('policy with patches', function (t) {
       'glue > hapi > joi > moment': [
         {
           patched: '2016-02-26T16:19:06.050Z',
+          policyInlineComment: 'http://example.com',
         },
       ],
     },
@@ -37,6 +38,9 @@ test('policy with patches', function (t) {
   t.notMatch(res, '# ignores vulnerabilities until expiry date; change ' +
     'duration by modifying expiry date\nignore:',
     'addComments does not add ignore comment');
+
+  t.notMatch(res, 'policyInlineComment',
+    'policyInlineComment is changed from data props to comment');
   t.end();
 });
 


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Through supporting inline annotation we can ensure that a person reviewing a policy file raised as part of a Pull/Merge Request has an link through to access further information

Before:

```
patch:
  'npm:uglify-js:20150824':
    - 'jade > transformers > uglify-js':
        patched: '2016-03-03T18:06:06.091Z'
  'npm:uglify-js:20151024':
    - 'jade > transformers > uglify-js':
        patched: '2016-03-03T18:06:06.091Z'
  'npm:semver:20150403':
    - '*':
```

After:

```
patch:
  'npm:uglify-js:20150824':
    - 'jade > transformers > uglify-js':
        patched: '2016-03-03T18:06:06.091Z'
      # https://snyk.io/vuln/npm:uglify-js:20150824#snyk-patches
  'npm:uglify-js:20151024':
    - 'jade > transformers > uglify-js':
        patched: '2016-03-03T18:06:06.091Z'
      # https://snyk.io/vuln/npm:uglify-js:20151024#snyk-patches
  'npm:semver:20150403':
    - '*':
      # https://snyk.io/vuln/npm:semver:20150403#snyk-patches
```
