### PR TITLE
fix: bump js-yaml to 3.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "debug": "^3.1.0",
     "email-validator": "^2.0.4",
-    "js-yaml": "^3.13.0",
+    "js-yaml": "^3.13.1",
     "lodash.clonedeep": "^4.5.0",
     "semver": "^6.0.0",
     "snyk-module": "^1.9.1",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Bumps `js-yaml` to 3.13.1 to fix a [vulnerability](https://app.snyk.io/vuln/SNYK-JS-JSYAML-174129)

#### Where should the reviewer start?
N/A

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
N/A

#### Screenshots
N/A

#### Additional questions
N/A