### PR TITLE
feat: upgrade snyk-module and remove @*

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/lib/filter/get-vuln-source.js
+++ b/lib/filter/get-vuln-source.js
@@ -6,7 +6,7 @@ var debug = require('debug')('snyk:policy');
 var resolve = require('snyk-resolve');
 var path = require('path');
 var statSync = require('fs').statSync;
-var moduleToObject = require('snyk-module');
+var { parsePackageString: moduleToObject } = require('snyk-module');
 
 function getVulnSource(vuln, cwd, live) {
   var from = vuln.from.slice(1).map(function (pkg) {

--- a/lib/match.js
+++ b/lib/match.js
@@ -70,12 +70,6 @@ function matchPath(from, path) {
       return true;
     }
 
-    // if we're missing the @version - add @* so the pkg is foobar@*
-    // so we have a good semver range
-    if (pkg.indexOf('@') === -1) {
-      pkg += '@*';
-    }
-
     var target = moduleToObject(pkg);
 
     var pkgVersion = target.version;

--- a/lib/match.js
+++ b/lib/match.js
@@ -6,7 +6,7 @@ module.exports = {
 var debug = require('debug')('snyk:policy');
 var debugPolicy = require('debug')('snyk:protect');
 var semver = require('semver');
-var moduleToObject = require('snyk-module');
+var { parsePackageString: moduleToObject } = require('snyk-module');
 
 // matchPath will take the array of dependencies that a vulnerability came from
 // and try to match it to a string `path`. The path will look like this:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "js-yaml": "^3.13.1",
     "lodash.clonedeep": "^4.5.0",
     "semver": "^6.0.0",
-    "snyk-module": "^1.9.1",
+    "snyk-module": "^2.0.2",
     "snyk-resolve": "^1.0.1",
     "snyk-try-require": "^1.3.1",
     "then-fs": "^2.0.0"


### PR DESCRIPTION
#### What does this PR do?

Bump snyk-module, which now exports a function.

Additionally:

feat: remove @* logic so we hit the fast path

This @* logic is not helpful here, because snyk-module already
returns '*' for unrecognised versions.

It is incorrect, because we don't append the start for scoped
packages, as we are incorrectly checking for an @. i.e.
@snyk/foo matches, and it shouldn't.

It also stops us hitting the new fast-path in snyk-module.