### PR TITLE
fix: upgrade debug and skip some logging

### DIFF
--- a/lib/filter/ignore.js
+++ b/lib/filter/ignore.js
@@ -56,8 +56,10 @@ function filterIgnored(ignore, vuln, filtered) {
       }
 
       if (pathMatch) {
-        debug('ignoring based on path match: %s ~= %s', path,
-          vuln.from.slice(1).join(' > '));
+        if (debug.enabled) {
+          debug('ignoring based on path match: %s ~= %s', path,
+            vuln.from.slice(1).join(' > '));
+        }
         return true;
       }
 

--- a/lib/filter/notes.js
+++ b/lib/filter/notes.js
@@ -44,8 +44,10 @@ function attachNotes(notes, vuln) {
       if (pathMatch) {
         // strip any control characters in the 3rd party reason file
         var reason = rule[path].reason.replace('/[\x00-\x1F\x7F-\x9F]/u', '');
-        debug('adding note based on path match: %s ~= %s', path,
-          vuln.from.slice(1).join(' > '));
+        if (debug.enabled) {
+          debug('adding note based on path match: %s ~= %s', path,
+            vuln.from.slice(1).join(' > '));
+        }
         vuln.note = 'Snyk policy in ' + rule[path].from +
           ' suggests ignoring this issue, with reason: ' + reason;
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,8 +93,10 @@ function load(root, options) {
 
     if (!ignorePolicy && Array.isArray(root)) {
       return resolve(mergePolicies(root, options).then(function (res) {
-        debug('final policy:');
-        debug(JSON.stringify(res, '', 2));
+        if (debug.enabled) {
+          debug('final policy:');
+          debug(JSON.stringify(res, '', 2));
+        }
         return res;
       }));
     }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "tap-only": "0.0.5"
   },
   "dependencies": {
-    "debug": "^3.1.0",
+    "debug": "^4.1.1",
     "email-validator": "^2.0.4",
     "js-yaml": "^3.13.1",
     "lodash.clonedeep": "^4.5.0",


### PR DESCRIPTION
#### What does this PR do?

Make sure we're not doing any extra work when `debug` logging is disabled.