### PR TITLE
chore: Update fixtures to correct patch urls

### DIFF
--- a/test/fixtures/patch-with-git-url.json
+++ b/test/fixtures/patch-with-git-url.json
@@ -48,7 +48,7 @@
       "id": "patch:npm:qs:20170213:7",
       "modificationTime": "2018-09-04T11:57:08.692963Z",
       "urls": [
-        "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/603_604.patch"
+        "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/603_604.patch"
       ],
       "version": "=6.0.3"
     },
@@ -57,7 +57,7 @@
       "id": "patch:npm:qs:20170213:6",
       "modificationTime": "2018-09-04T11:57:08.691571Z",
       "urls": [
-        "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/602_604.patch"
+        "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/602_604.patch"
       ],
       "version": "=6.0.2"
     },
@@ -66,7 +66,7 @@
       "id": "patch:npm:qs:20170213:5",
       "modificationTime": "2018-09-04T11:57:08.690235Z",
       "urls": [
-        "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/611_612.patch"
+        "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/611_612.patch"
       ],
       "version": "=6.1.1"
     },
@@ -75,7 +75,7 @@
       "id": "patch:npm:qs:20170213:4",
       "modificationTime": "2018-09-04T11:57:08.688957Z",
       "urls": [
-        "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/610_612.patch"
+        "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/610_612.patch"
       ],
       "version": "=6.1.0"
     },
@@ -84,7 +84,7 @@
       "id": "patch:npm:qs:20170213:3",
       "modificationTime": "2018-09-04T11:57:08.687714Z",
       "urls": [
-        "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/622_623.patch"
+        "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/622_623.patch"
       ],
       "version": "=6.2.2"
     },
@@ -93,7 +93,7 @@
       "id": "patch:npm:qs:20170213:2",
       "modificationTime": "2018-09-04T11:57:08.686294Z",
       "urls": [
-        "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/621_623.patch"
+        "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/621_623.patch"
       ],
       "version": "=6.2.1"
     },
@@ -102,7 +102,7 @@
       "id": "patch:npm:qs:20170213:1",
       "modificationTime": "2018-09-04T11:57:08.684986Z",
       "urls": [
-        "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/631_632.patch"
+        "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/631_632.patch"
       ],
       "version": "=6.3.1"
     },
@@ -111,7 +111,7 @@
       "id": "patch:npm:qs:20170213:0",
       "modificationTime": "2018-09-04T11:57:08.683816Z",
       "urls": [
-        "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/630_632.patch"
+        "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/630_632.patch"
       ],
       "version": "=6.3.0"
     }


### PR DESCRIPTION
Update fixtures to point to the correct location of our patch urls 