### PR TITLE
feat: bump snyk-module (no more node 6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lodash.clonedeep": "^4.5.0",
     "prettier": "^1.19.1",
     "semver": "^6.0.0",
-    "snyk-module": "^2.0.2",
+    "snyk-module": "^3.0.0",
     "snyk-resolve": "^1.0.1",
     "snyk-try-require": "^1.3.1",
     "then-fs": "^2.0.0"


### PR DESCRIPTION
The major version bump here is about dropping node 6 support, which is fine.