### PR TITLE
feat: remove then-fs dependency

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const fs = require('then-fs');
+const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('snyk:policy');
 const match = require('./match');
@@ -103,13 +103,17 @@ function load(root, options) {
       );
     }
 
-    resolve(fs.readFile(filename, 'utf8').then(parse.import));
+    resolve(parse.import(fs.readFileSync(filename, 'utf8')));
   });
 
   const promises = [
     promise,
-    fs.stat(filename).catch(function () {
-      return {};
+    new Promise((resolve) => {
+      try {
+        resolve(fs.statSync(filename));
+      } catch (error) {
+        resolve({});
+      }
     }),
   ];
 
@@ -219,7 +223,7 @@ function save(object, root, spinner) {
       return parse.export(object);
     })
     .then(function (yaml) {
-      return fs.writeFile(filename, yaml);
+      return fs.writeFileSync(filename, yaml);
     })
     .then(spinner.clear(lbl));
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "semver": "^6.0.0",
     "snyk-module": "^3.0.0",
     "snyk-resolve": "^1.0.1",
-    "snyk-try-require": "^1.3.1",
-    "then-fs": "^2.0.0"
+    "snyk-try-require": "^1.3.1"
   },
   "repository": {
     "type": "git",

--- a/test/unit/get-by-vuln.test.js
+++ b/test/unit/get-by-vuln.test.js
@@ -1,6 +1,6 @@
 const test = require('tap-only');
 const fixtures = __dirname + '/../fixtures';
-const fs = require('then-fs');
+const fs = require('fs');
 const getByVuln = require('../../lib/match').getByVuln;
 const loadFromText = require('../../').loadFromText;
 const policy = require(fixtures + '/ignore/parsed.json');
@@ -35,8 +35,7 @@ test('getByVuln with star rules', function (t) {
     })
     .pop();
 
-  return fs
-    .readFile(fixtures + '/star-rule.txt', 'utf8')
+  return Promise.resolve(fs.readFileSync(fixtures + '/star-rule.txt', 'utf8'))
     .then(loadFromText)
     .then(function (policy) {
       const res = getByVuln(policy, vuln);
@@ -54,8 +53,7 @@ test('getByVuln with exact match rules', function (t) {
     })
     .pop();
 
-  return fs
-    .readFile(fixtures + '/exact-rule.txt', 'utf8')
+  return Promise.resolve(fs.readFileSync(fixtures + '/exact-rule.txt', 'utf8'))
     .then(loadFromText)
     .then(function (policy) {
       const res = getByVuln(policy, vuln);

--- a/test/unit/policy-save.test.js
+++ b/test/unit/policy-save.test.js
@@ -4,12 +4,12 @@ const fixtures = __dirname + '/../fixtures';
 const path = require('path');
 const sinon = require('sinon');
 const writeSpy = sinon.spy();
-const fs = require('then-fs');
+const fs = require('fs');
 const policy = proxyquire('../..', {
-  'then-fs': {
-    writeFile: function (filename, body) {
+  fs: {
+    writeFileSync: function (filename, body) {
       writeSpy(filename, body);
-      return Promise.resolve();
+      return;
     },
   },
 });
@@ -17,8 +17,7 @@ const policy = proxyquire('../..', {
 test('policy.save', function (t) {
   const filename = path.resolve(fixtures + '/ignore/.snyk');
   let asText = '';
-  return fs
-    .readFile(filename, 'utf8')
+  return Promise.resolve(fs.readFileSync(filename, 'utf8'))
     .then(function (res) {
       asText = res.trim();
       return asText;

--- a/test/unit/policy.test.js
+++ b/test/unit/policy.test.js
@@ -2,7 +2,7 @@ const test = require('tap-only');
 const policy = require('../..');
 const demunge = require('../../lib/parser').demunge;
 const path = require('path');
-const fs = require('then-fs');
+const fs = require('fs');
 const fixtures = __dirname + '/../fixtures';
 
 test('module loads', function (t) {
@@ -120,8 +120,7 @@ test('policy.load (merge)', function (t) {
 });
 
 test('policy.loadFromText', function (t) {
-  return fs
-    .readFile(fixtures + '/ignore/.snyk', 'utf8')
+  return Promise.resolve(fs.readFileSync(fixtures + '/ignore/.snyk', 'utf8'))
     .then(policy.loadFromText)
     .then(function (fromText) {
       return policy.load(fixtures + '/ignore').then(function (fromDir) {


### PR DESCRIPTION
Following removal of `then-fs` in snyk CLI https://github.com/snyk/snyk/pull/1137 I'm trying to remove it from other dependencies as well.