### PR TITLE
feat: swap out then-fs for promise-fs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const fs = require('then-fs');
+const fs = require('promise-fs');
 const path = require('path');
 const debug = require('debug')('snyk:policy');
 const match = require('./match');

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "email-validator": "^2.0.4",
     "js-yaml": "^3.13.1",
     "lodash.clonedeep": "^4.5.0",
+    "promise-fs": "^2.1.1",
     "semver": "^6.0.0",
     "snyk-module": "^3.0.0",
     "snyk-resolve": "^1.0.1",
-    "snyk-try-require": "^1.3.1",
-    "then-fs": "^2.0.0"
+    "snyk-try-require": "^1.3.1"
   },
   "repository": {
     "type": "git",

--- a/test/unit/get-by-vuln.test.js
+++ b/test/unit/get-by-vuln.test.js
@@ -1,6 +1,6 @@
 const test = require('tap-only');
 const fixtures = __dirname + '/../fixtures';
-const fs = require('then-fs');
+const fs = require('promise-fs');
 const getByVuln = require('../../lib/match').getByVuln;
 const loadFromText = require('../../').loadFromText;
 const policy = require(fixtures + '/ignore/parsed.json');

--- a/test/unit/policy-save.test.js
+++ b/test/unit/policy-save.test.js
@@ -4,9 +4,9 @@ const fixtures = __dirname + '/../fixtures';
 const path = require('path');
 const sinon = require('sinon');
 const writeSpy = sinon.spy();
-const fs = require('then-fs');
+const fs = require('promise-fs');
 const policy = proxyquire('../..', {
-  'then-fs': {
+  'promise-fs': {
     writeFile: function (filename, body) {
       writeSpy(filename, body);
       return Promise.resolve();

--- a/test/unit/policy.test.js
+++ b/test/unit/policy.test.js
@@ -2,7 +2,7 @@ const test = require('tap-only');
 const policy = require('../..');
 const demunge = require('../../lib/parser').demunge;
 const path = require('path');
-const fs = require('then-fs');
+const fs = require('promise-fs');
 const fixtures = __dirname + '/../fixtures';
 
 test('module loads', function (t) {


### PR DESCRIPTION
then-fs monkey patches the stdlib, which causes problems for jest, c.f. https://github.com/facebook/jest/pull/8331

promise-fs is a drop-in replacement here, for us.
