### PR TITLE
feat: bump snyk deps to pick up then-fs drops

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "promise-fs": "^2.1.1",
     "semver": "^6.0.0",
     "snyk-module": "^3.0.0",
-    "snyk-resolve": "^1.0.1",
-    "snyk-try-require": "^1.3.1"
+    "snyk-resolve": "^1.1.0",
+    "snyk-try-require": "^2.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We're trying to shake then-fs out of the tree here, and one of our
deps in our tree had a major version bump, which we must adopt here.

The major version bump comes with a node baseline change, which we are assuming we're okay with here.