### PR TITLE
chore: extend policy.ignore with security policy ignore

### DIFF
--- a/lib/filter/index.js
+++ b/lib/filter/index.js
@@ -4,6 +4,7 @@ const debug = require('debug')('snyk:policy');
 const ignore = require('./ignore');
 const patch = require('./patch');
 const notes = require('./notes');
+const add = require('../add');
 
 // warning: mutates vulns
 function filter(vulns, policy, root) {
@@ -19,6 +20,14 @@ function filter(vulns, policy, root) {
     ignore: [],
     patch: [],
   };
+
+  // add ignores from security policies
+  for (let i = vulns.vulnerabilities.length - 1; i >= 0; i--) {
+    const vuln = vulns.vulnerabilities[i];
+    if (vuln.securityPolicyMeta && vuln.securityPolicyMeta.ignore) {
+      policy = add(policy, 'ignore', vuln.securityPolicyMeta.ignoreData);
+    }
+  }
 
   // strip the ignored modules from the results
   vulns.vulnerabilities = ignore(


### PR DESCRIPTION
POC 2

Enabling ignore action of security policies. 
Here we extend `policy.ignore` with the ignore meta data generated by security policy. This approach should cover most (if not all) flows

Tested  UI re-test, CLI test and wizard - all worked