### PR TITLE
feat: upgrade semver to 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "js-yaml": "^3.13.1",
     "lodash.clonedeep": "^4.5.0",
     "promise-fs": "^2.1.1",
-    "semver": "^6.0.0",
+    "semver": "^7.3.4",
     "snyk-module": "^3.0.0",
     "snyk-resolve": "^1.1.0",
     "snyk-try-require": "^2.0.0"


### PR DESCRIPTION
https://github.com/npm/node-semver/blob/master/CHANGELOG.md#700

> Refactor module into separate files for better tree-shaking
> Drop support for very old node versions, use const/let, => functions, and classes.

I believe this drops support for node 0.x.
