### PR TITLE
feat: support security policies ignore action

### DIFF
--- a/lib/filter/ignore.js
+++ b/lib/filter/ignore.js
@@ -21,59 +21,93 @@ function filterIgnored(ignore, vuln, filtered) {
 
   return vuln
     .map(function (vuln) {
-      if (!ignore[vuln.id]) {
+      const applySecurityPolicyIgnore = vulnHasSecurityPolicyIgnore(vuln);
+      if (!ignore[vuln.id] && !applySecurityPolicyIgnore) {
         return vuln;
       }
 
       debug('%s has rules', vuln.id);
 
-      // logic: loop through all rules (from `ignore[vuln.id]`), and if *any* dep
-      // paths match our vuln.from dep chain AND the rule hasn't expired, then the
-      // vulnerability is ignored. if none of the rules match, then let we'll
-      // keep it.
+      let appliedRules = [];
 
-      // if rules.find, then ignore vuln
-      const appliedRules = ignore[vuln.id].filter(function (rule) {
-        const path = Object.keys(rule)[0]; // this is a string
-        let expires = rule[path].expires;
+      if (applySecurityPolicyIgnore) {
+        // logic: if vuln has securityPolicyMetaData.ignore rule, that means it comes
+        // after security rule applied with the ignore action, thus we have to apply
+        // this ignore and not any others.
+        // Security policies ignores we apply to all paths "*" and disregardIfFixable=false
+        const rule = vuln.securityPolicyMetaData.ignore;
 
-        if (expires && expires.toJSON) {
-          expires = expires.toJSON();
-        }
+        const {
+          created,
+          disregardIfFixable,
+          ignoredBy,
+          path,
+          reason = '',
+          reasonType,
+          source,
+        } = rule;
 
-        // first check if the path is a match on the rule
-        const pathMatch = matchToRule(vuln, rule);
+        appliedRules = [
+          {
+            [path[0]]: {
+              reason,
+              reasonType,
+              source,
+              ignoredBy,
+              created,
+              disregardIfFixable,
+            },
+          },
+        ];
+      } else {
+        // logic: loop through all rules (from `ignore[vuln.id]`), and if *any* dep
+        // paths match our vuln.from dep chain AND the rule hasn't expired, then the
+        // vulnerability is ignored. if none of the rules match, then let we'll
+        // keep it.
 
-        if (pathMatch && expires && expires < now) {
-          debug('%s vuln rule has expired (%s)', vuln.id, expires);
-          return false;
-        }
+        // if rules.find, then ignore vuln
+        appliedRules = ignore[vuln.id].filter(function (rule) {
+          const path = Object.keys(rule)[0]; // this is a string
+          let expires = rule[path].expires;
 
-        if (
-          pathMatch &&
-          rule[path].disregardIfFixable &&
-          (vuln.isUpgradable || vuln.isPatchable)
-        ) {
-          debug(
-            '%s vuln is fixable and rule is set to disregard if fixable',
-            vuln.id
-          );
-          return false;
-        }
-
-        if (pathMatch) {
-          if (debug.enabled) {
-            debug(
-              'ignoring based on path match: %s ~= %s',
-              path,
-              vuln.from.slice(1).join(' > ')
-            );
+          if (expires && expires.toJSON) {
+            expires = expires.toJSON();
           }
-          return true;
-        }
 
-        return false;
-      });
+          // first check if the path is a match on the rule
+          const pathMatch = matchToRule(vuln, rule);
+
+          if (pathMatch && expires && expires < now) {
+            debug('%s vuln rule has expired (%s)', vuln.id, expires);
+            return false;
+          }
+
+          if (
+            pathMatch &&
+            rule[path].disregardIfFixable &&
+            (vuln.isUpgradable || vuln.isPatchable)
+          ) {
+            debug(
+              '%s vuln is fixable and rule is set to disregard if fixable',
+              vuln.id
+            );
+            return false;
+          }
+
+          if (pathMatch) {
+            if (debug.enabled) {
+              debug(
+                'ignoring based on path match: %s ~= %s',
+                path,
+                vuln.from.slice(1).join(' > ')
+              );
+            }
+            return true;
+          }
+
+          return false;
+        });
+      }
 
       if (appliedRules.length) {
         vuln.filtered = {
@@ -91,3 +125,7 @@ function filterIgnored(ignore, vuln, filtered) {
     })
     .filter(Boolean);
 }
+
+const vulnHasSecurityPolicyIgnore = (vuln) => {
+  return !!(vuln.securityPolicyMetaData && vuln.securityPolicyMetaData.ignore);
+};

--- a/test/fixtures/ignore-security-policy/.snyk
+++ b/test/fixtures/ignore-security-policy/.snyk
@@ -1,0 +1,25 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'npm:hawk:20160119':
+    - sqlite > sqlite3 > node-pre-gyp > request > hawk:
+        reason: hawk got bumped
+        expires: '2116-03-01T14:30:04.136Z'
+  'npm:is-my-json-valid:20160118':
+    - sqlite > sqlite3 > node-pre-gyp > request > har-validator > is-my-json-valid:
+        reason: dev tool
+        expires: '2116-03-01T14:30:04.136Z'
+  'npm:tar:20151103':
+    - sqlite > sqlite3 > node-pre-gyp > tar-pack > tar:
+        reason: none given
+        expires: '2116-03-01T14:30:04.137Z'
+  'npm:method-override:20170927':
+    - '*':
+        reason: none given
+        disregardIfFixable: true
+  'npm:marked:20170907':
+    - '*':
+        reason: none given
+        disregardIfFixable: true
+patch: {}
+version: v1.0.0

--- a/test/fixtures/ignore-security-policy/package.json
+++ b/test/fixtures/ignore-security-policy/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ignore",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "snyk": "*",
+    "sqlite": "0.0.2"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "snyk test && echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/test/fixtures/ignore-security-policy/parsed.json
+++ b/test/fixtures/ignore-security-policy/parsed.json
@@ -1,0 +1,49 @@
+{
+  "ignore": {
+    "npm:hawk:20160119": [
+      {
+        "sqlite > sqlite3 > node-pre-gyp > request > hawk": {
+          "reason": "None given",
+          "expires": "2016-03-01T14:30:04.136Z"
+        }
+      }
+    ],
+    "npm:is-my-json-valid:20160118": [
+      {
+        "sqlite > sqlite3 > node-pre-gyp > request > har-validator > is-my-json-valid": {
+          "reason": "None given",
+          "expires": "2016-03-01T14:30:04.136Z"
+        }
+      }
+    ],
+    "npm:tar:20151103": [
+      {
+        "sqlite > sqlite3 > node-pre-gyp > tar-pack > tar": {
+          "reason": "None given",
+          "expires": "2016-03-01T14:30:04.137Z"
+        }
+      }
+    ],
+    "npm:method-override:20170927": [
+      {
+        "*": {
+          "reason": "none given",
+          "disregardIfFixable": true
+        }
+      }
+    ],
+    "npm:marked:20170907": [
+      {
+        "*": {
+          "reason": "none given",
+          "disregardIfFixable": true
+        }
+      }
+    ]
+  },
+  "version": "v1",
+  "patch": {},
+  "__filename": "test/fixtures/ignore/.snyk",
+  "__modified": "2016-03-07T14:52:42.000Z",
+  "__created": "2016-03-07T14:25:45.000Z"
+}

--- a/test/fixtures/ignore-security-policy/vulns-incomplete-security-metadata.json
+++ b/test/fixtures/ignore-security-policy/vulns-incomplete-security-metadata.json
@@ -1,0 +1,270 @@
+{
+  "ok": false,
+  "vulnerabilities": [
+    {
+      "title": "Regular Expression Denial of Service",
+      "credit": [
+        "Adam Baldwin"
+      ],
+      "creationTime": "2016-01-19T23:24:51.834Z",
+      "modificationTime": "2016-01-19T23:24:51.834Z",
+      "publicationTime": "2016-01-19T21:51:35.396Z",
+      "description": "## Overview\nA [Regular expression Denial of Service (ReDoS)](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS) vulnerability exists in `hawk` package, affecting version 4.1.0 and below.\n\n\"The Regular expression Denial of Service (ReDoS) is a Denial of Service attack, that exploits the fact that most Regular Expression implementations may reach extreme situations that cause them to work very slowly (exponentially related to input size). An attacker can then cause a program using a Regular Expression to enter these extreme situations and then hang for a very long time.\" [1](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS)\n\n## References\n- https://github.com/hueniverse/hawk/issues/168\n- https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS\n",
+      "semver": {
+        "vulnerable": "<=3.1.2 || >= 4.0.0 <4.1.1",
+        "unaffected": ">3.1.2 < 4.0.0 || >=4.1.1"
+      },
+      "CVSSv3": "",
+      "severity": "low",
+      "identifiers": {
+        "CWE": [
+          "CWE-400"
+        ],
+        "CVE": [],
+        "NSP": 77
+      },
+      "patches": [
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/hawk/20160119/hawk_20160119_0_0_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+          ],
+          "version": "<4.1.1 >=4.0.0",
+          "modificationTime": "2016-01-20T12:51:35.396Z",
+          "comments": [],
+          "id": "patch:npm:hawk:20160119:0"
+        },
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/hawk/20160119/hawk_20160119_0_1_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+          ],
+          "version": "<4.0.0 >=3.0.0",
+          "modificationTime": "2016-01-20T12:51:35.396Z",
+          "comments": [],
+          "id": "patch:npm:hawk:20160119:1"
+        }
+      ],
+      "moduleName": "hawk",
+      "id": "npm:hawk:20160119",
+      "from": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14",
+        "request@2.64.0",
+        "hawk@3.1.0"
+      ],
+      "upgradePath": [
+        false,
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14",
+        "request@2.64.0",
+        "hawk@3.1.3"
+      ],
+      "version": "3.1.0",
+      "name": "hawk",
+      "__filename": "/Users/remy/Sites/snyk-tests/ignore/node_modules/sqlite/node_modules/sqlite3/node_modules/node-pre-gyp/node_modules/request/node_modules/hawk/package.json",
+      "bundled": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14"
+      ]
+    },
+    {
+      "title": "Regular Expression Denial of Service",
+      "credit": [
+        "Adam Baldwin"
+      ],
+      "creationTime": "2016-01-18T12:28:12.885Z",
+      "modificationTime": "2016-01-18T12:28:12.885Z",
+      "publicationTime": "2016-01-18T04:29:55.903Z",
+      "description": "## Overview\nA [Regular expression Denial of Service (ReDoS)](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS) vulnerability exists in `utc-millisec` validator of `is-my-json-valid` package, affecting version 2.12.3 and below.\n\n\"The Regular expression Denial of Service (ReDoS) is a Denial of Service attack, that exploits the fact that most Regular Expression implementations may reach extreme situations that cause them to work very slowly (exponentially related to input size). An attacker can then cause a program using a Regular Expression to enter these extreme situations and then hang for a very long time.\" [1](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS)\n\n## References\n- https://nodesecurity.io/advisories/76\n- https://github.com/mafintosh/is-my-json-valid/commit/eca4beb21e61877d76fdf6bea771f72f39544d9b\n- https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS\n\n\n",
+      "semver": {
+        "vulnerable": "<=2.12.3",
+        "unaffected": ">=2.12.4"
+      },
+      "CVSSv3": "",
+      "severity": "low",
+      "identifiers": {
+        "CWE": [
+          "CWE-400"
+        ],
+        "CVE": [],
+        "NSP": 76
+      },
+      "patches": [
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/is-my-json-valid/20160118/imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+          ],
+          "version": "<=2.12.3 >=2.0.3",
+          "modificationTime": "2016-01-21T12:51:35.396Z",
+          "comments": [],
+          "id": "patch:npm:is-my-json-valid:20160118:0"
+        },
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/is-my-json-valid/20160118/imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+          ],
+          "version": "<2.0.3 >=1.3.4",
+          "modificationTime": "2016-01-21T12:51:35.396Z",
+          "comments": [],
+          "id": "patch:npm:is-my-json-valid:20160118:1"
+        }
+      ],
+      "moduleName": "is-my-json-valid",
+      "id": "npm:is-my-json-valid:20160118",
+      "from": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14",
+        "request@2.64.0",
+        "har-validator@1.8.0",
+        "is-my-json-valid@2.12.2"
+      ],
+      "upgradePath": [
+        false,
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14",
+        "request@2.64.0",
+        "har-validator@1.8.0",
+        "is-my-json-valid@2.12.4"
+      ],
+      "version": "2.12.2",
+      "name": "is-my-json-valid",
+      "__filename": "/Users/remy/Sites/snyk-tests/ignore/node_modules/sqlite/node_modules/sqlite3/node_modules/node-pre-gyp/node_modules/request/node_modules/har-validator/node_modules/is-my-json-valid/package.json",
+      "bundled": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14"
+      ],
+      "securityPolicyMetaData": {}
+    },
+    {
+      "title": "Symlink Arbitrary File Overwrite",
+      "credit": [
+        "Tim Cuthbertson"
+      ],
+      "creationTime": "2015-11-06T02:09:36.182Z",
+      "modificationTime": "2015-11-06T02:09:36.182Z",
+      "publicationTime": "2015-11-03T07:15:12.900Z",
+      "description": "## Overview\nThe [`tar`](https://www.npmjs.com/package/tar) module prior to version 2.0.0 does not properly normalize symbolic links pointing to targets outside the extraction root. As a result, packages may hold symbolic links to parent and sibling directories and overwrite those files when the package is extracted.\n\n## Remediation\nUpgrade to version 2.0.0 or greater. \nIf a direct dependency update is not possible, use [`snyk wizard`](https://snyk.io/documentation/#wizard) to patch this vulnerability.\n\n## References\n- https://nodesecurity.io/advisories/57\n- https://github.com/npm/node-tar/commit/a5337a6cd58a2d800fc03b3781a25751cf459f28\n- https://github.com/npm/npm/releases/tag/v2.7.5\n",
+      "semver": {
+        "vulnerable": "<2.0.0",
+        "unaffected": ">=2.0.0"
+      },
+      "CVSSv3": "",
+      "severity": "high",
+      "identifiers": {
+        "CWE": [],
+        "CVE": [],
+        "NSP": 57
+      },
+      "patches": [
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/tar/20151103/tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+          ],
+          "version": "<2.0.0 >=0.1.13",
+          "modificationTime": "2015-11-17T09:29:10.000Z",
+          "comments": [
+            "https://github.com/npm/node-tar/commit/a5337a6cd58a2d800fc03b3781a25751cf459f28.patch"
+          ],
+          "id": "patch:npm:tar:20151103:0"
+        },
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/tar/20151103/tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+          ],
+          "version": "<0.1.13 >0.0.1",
+          "modificationTime": "2015-11-17T09:29:10.000Z",
+          "comments": [
+            "https://github.com/npm/node-tar/commit/a5337a6cd58a2d800fc03b3781a25751cf459f28.patch"
+          ],
+          "id": "patch:npm:tar:20151103:1"
+        }
+      ],
+      "moduleName": "tar",
+      "id": "npm:tar:20151103",
+      "from": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14",
+        "tar-pack@2.0.0",
+        "tar@0.1.20"
+      ],
+      "upgradePath": [
+        false,
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.15",
+        "tar-pack@3.1.0",
+        "tar@2.2.1"
+      ],
+      "version": "0.1.20",
+      "name": "tar",
+      "__filename": "/Users/remy/Sites/snyk-tests/ignore/node_modules/sqlite/node_modules/sqlite3/node_modules/node-pre-gyp/node_modules/tar-pack/node_modules/tar/package.json",
+      "bundled": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14"
+      ],
+      "securityPolicyMetaData": {}
+    },
+    {
+      "title": "Regular Expression Denial of Service (ReDoS)",
+      "credit": [
+        "Cristian-Alexandru Staicu"
+      ],
+      "moduleName": "marked",
+      "packageName": "marked",
+      "language": "js",
+      "packageManager": "npm",
+      "description": "## Overview\n[`marked`](https://www.npmjs.com/package/marked) is a full-featured markdown parser and compiler.\n\nAffected versions of this package are vulnerable to Regular expression Denial of Service (ReDoS) attacks when parsing the input markdown content (1,000 characters costs around 6 seconds matching time).\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Many Regular Expression implementations may reach extreme situations that cause them to work very slowly (exponentially related to input size), allowing an attacker to exploit this and can cause the program to enter these extreme situations by using a specially crafted input and cause the service to excessively consume CPU, resulting in a Denial of Service.\n\nYou can read more about `Regular Expression Denial of Service (ReDoS)` on our [blog](https://snyk.io/blog/redos-and-catastrophic-backtracking/).\n\n## Remediation\nThere is no fix version yet. At time of writing, latest version is `0.3.6`.\n\n## References\n- [Github Issue](https://github.com/chjj/marked/issues/937)\n",
+      "identifiers": {
+        "NSP": 531,
+        "CWE": [
+          "CWE-400"
+        ],
+        "CVE": [],
+        "ALTERNATIVE": [
+          "SNYK-JS-MARKED-10782"
+        ]
+      },
+      "semver": {
+        "vulnerable": "*",
+        "unaffected": "<0.0.0"
+      },
+      "cvssScore": 7.5,
+      "patches": [],
+      "severity": "high",
+      "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "disclosureTime": "2017-09-07T21:00:00.000Z",
+      "publicationTime": "2017-09-21T08:07:51.834Z",
+      "modificationTime": "2017-09-21T08:07:51.834Z",
+      "creationTime": "2017-09-21T08:07:51.834Z",
+      "id": "npm:marked:20170907",
+      "alternativeIds": [
+        "SNYK-JS-MARKED-10782"
+      ],
+      "from": [
+        "goof@0.0.3",
+        "marked@0.3.5"
+      ],
+      "upgradePath": [],
+      "version": "0.3.5",
+      "name": "marked",
+      "isUpgradable": false,
+      "isPatchable": false,
+      "__filename": "/Users/Josh/Sites/snyk/goof/node_modules/marked/package.json",
+      "parentDepType": "prod"
+    }
+  ],
+  "dependencyCount": 108
+}

--- a/test/fixtures/ignore-security-policy/vulns-security-metadata.json
+++ b/test/fixtures/ignore-security-policy/vulns-security-metadata.json
@@ -1,0 +1,284 @@
+{
+  "ok": false,
+  "vulnerabilities": [
+    {
+      "title": "Regular Expression Denial of Service",
+      "credit": [
+        "Adam Baldwin"
+      ],
+      "creationTime": "2016-01-19T23:24:51.834Z",
+      "modificationTime": "2016-01-19T23:24:51.834Z",
+      "publicationTime": "2016-01-19T21:51:35.396Z",
+      "description": "## Overview\nA [Regular expression Denial of Service (ReDoS)](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS) vulnerability exists in `hawk` package, affecting version 4.1.0 and below.\n\n\"The Regular expression Denial of Service (ReDoS) is a Denial of Service attack, that exploits the fact that most Regular Expression implementations may reach extreme situations that cause them to work very slowly (exponentially related to input size). An attacker can then cause a program using a Regular Expression to enter these extreme situations and then hang for a very long time.\" [1](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS)\n\n## References\n- https://github.com/hueniverse/hawk/issues/168\n- https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS\n",
+      "semver": {
+        "vulnerable": "<=3.1.2 || >= 4.0.0 <4.1.1",
+        "unaffected": ">3.1.2 < 4.0.0 || >=4.1.1"
+      },
+      "CVSSv3": "",
+      "severity": "low",
+      "identifiers": {
+        "CWE": [
+          "CWE-400"
+        ],
+        "CVE": [],
+        "NSP": 77
+      },
+      "patches": [
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/hawk/20160119/hawk_20160119_0_0_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+          ],
+          "version": "<4.1.1 >=4.0.0",
+          "modificationTime": "2016-01-20T12:51:35.396Z",
+          "comments": [],
+          "id": "patch:npm:hawk:20160119:0"
+        },
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/hawk/20160119/hawk_20160119_0_1_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+          ],
+          "version": "<4.0.0 >=3.0.0",
+          "modificationTime": "2016-01-20T12:51:35.396Z",
+          "comments": [],
+          "id": "patch:npm:hawk:20160119:1"
+        }
+      ],
+      "moduleName": "hawk",
+      "id": "npm:hawk:20160119",
+      "from": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14",
+        "request@2.64.0",
+        "hawk@3.1.0"
+      ],
+      "upgradePath": [
+        false,
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14",
+        "request@2.64.0",
+        "hawk@3.1.3"
+      ],
+      "version": "3.1.0",
+      "name": "hawk",
+      "__filename": "/Users/remy/Sites/snyk-tests/ignore/node_modules/sqlite/node_modules/sqlite3/node_modules/node-pre-gyp/node_modules/request/node_modules/hawk/package.json",
+      "bundled": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14"
+      ]
+    },
+    {
+      "title": "Regular Expression Denial of Service",
+      "credit": [
+        "Adam Baldwin"
+      ],
+      "creationTime": "2016-01-18T12:28:12.885Z",
+      "modificationTime": "2016-01-18T12:28:12.885Z",
+      "publicationTime": "2016-01-18T04:29:55.903Z",
+      "description": "## Overview\nA [Regular expression Denial of Service (ReDoS)](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS) vulnerability exists in `utc-millisec` validator of `is-my-json-valid` package, affecting version 2.12.3 and below.\n\n\"The Regular expression Denial of Service (ReDoS) is a Denial of Service attack, that exploits the fact that most Regular Expression implementations may reach extreme situations that cause them to work very slowly (exponentially related to input size). An attacker can then cause a program using a Regular Expression to enter these extreme situations and then hang for a very long time.\" [1](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS)\n\n## References\n- https://nodesecurity.io/advisories/76\n- https://github.com/mafintosh/is-my-json-valid/commit/eca4beb21e61877d76fdf6bea771f72f39544d9b\n- https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS\n\n\n",
+      "semver": {
+        "vulnerable": "<=2.12.3",
+        "unaffected": ">=2.12.4"
+      },
+      "CVSSv3": "",
+      "severity": "low",
+      "identifiers": {
+        "CWE": [
+          "CWE-400"
+        ],
+        "CVE": [],
+        "NSP": 76
+      },
+      "patches": [
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/is-my-json-valid/20160118/imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+          ],
+          "version": "<=2.12.3 >=2.0.3",
+          "modificationTime": "2016-01-21T12:51:35.396Z",
+          "comments": [],
+          "id": "patch:npm:is-my-json-valid:20160118:0"
+        },
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/is-my-json-valid/20160118/imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+          ],
+          "version": "<2.0.3 >=1.3.4",
+          "modificationTime": "2016-01-21T12:51:35.396Z",
+          "comments": [],
+          "id": "patch:npm:is-my-json-valid:20160118:1"
+        }
+      ],
+      "moduleName": "is-my-json-valid",
+      "id": "npm:is-my-json-valid:20160118",
+      "from": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14",
+        "request@2.64.0",
+        "har-validator@1.8.0",
+        "is-my-json-valid@2.12.2"
+      ],
+      "upgradePath": [
+        false,
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14",
+        "request@2.64.0",
+        "har-validator@1.8.0",
+        "is-my-json-valid@2.12.4"
+      ],
+      "version": "2.12.2",
+      "name": "is-my-json-valid",
+      "__filename": "/Users/remy/Sites/snyk-tests/ignore/node_modules/sqlite/node_modules/sqlite3/node_modules/node-pre-gyp/node_modules/request/node_modules/har-validator/node_modules/is-my-json-valid/package.json",
+      "bundled": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14"
+      ]
+    },
+    {
+      "title": "Symlink Arbitrary File Overwrite",
+      "credit": [
+        "Tim Cuthbertson"
+      ],
+      "creationTime": "2015-11-06T02:09:36.182Z",
+      "modificationTime": "2015-11-06T02:09:36.182Z",
+      "publicationTime": "2015-11-03T07:15:12.900Z",
+      "description": "## Overview\nThe [`tar`](https://www.npmjs.com/package/tar) module prior to version 2.0.0 does not properly normalize symbolic links pointing to targets outside the extraction root. As a result, packages may hold symbolic links to parent and sibling directories and overwrite those files when the package is extracted.\n\n## Remediation\nUpgrade to version 2.0.0 or greater. \nIf a direct dependency update is not possible, use [`snyk wizard`](https://snyk.io/documentation/#wizard) to patch this vulnerability.\n\n## References\n- https://nodesecurity.io/advisories/57\n- https://github.com/npm/node-tar/commit/a5337a6cd58a2d800fc03b3781a25751cf459f28\n- https://github.com/npm/npm/releases/tag/v2.7.5\n",
+      "semver": {
+        "vulnerable": "<2.0.0",
+        "unaffected": ">=2.0.0"
+      },
+      "CVSSv3": "",
+      "severity": "high",
+      "identifiers": {
+        "CWE": [],
+        "CVE": [],
+        "NSP": 57
+      },
+      "patches": [
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/tar/20151103/tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+          ],
+          "version": "<2.0.0 >=0.1.13",
+          "modificationTime": "2015-11-17T09:29:10.000Z",
+          "comments": [
+            "https://github.com/npm/node-tar/commit/a5337a6cd58a2d800fc03b3781a25751cf459f28.patch"
+          ],
+          "id": "patch:npm:tar:20151103:0"
+        },
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/tar/20151103/tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+          ],
+          "version": "<0.1.13 >0.0.1",
+          "modificationTime": "2015-11-17T09:29:10.000Z",
+          "comments": [
+            "https://github.com/npm/node-tar/commit/a5337a6cd58a2d800fc03b3781a25751cf459f28.patch"
+          ],
+          "id": "patch:npm:tar:20151103:1"
+        }
+      ],
+      "moduleName": "tar",
+      "id": "npm:tar:20151103",
+      "from": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14",
+        "tar-pack@2.0.0",
+        "tar@0.1.20"
+      ],
+      "upgradePath": [
+        false,
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.15",
+        "tar-pack@3.1.0",
+        "tar@2.2.1"
+      ],
+      "version": "0.1.20",
+      "name": "tar",
+      "__filename": "/Users/remy/Sites/snyk-tests/ignore/node_modules/sqlite/node_modules/sqlite3/node_modules/node-pre-gyp/node_modules/tar-pack/node_modules/tar/package.json",
+      "bundled": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14"
+      ],
+      "securityPolicyMetaData": {
+        "ignore": {
+          "path": [
+            "*"
+          ],
+          "reason": "",
+          "reasonType": "wont-fix",
+          "source": "security-policy",
+          "ignoredBy": {
+            "id": "22A6B3BE-ABEF-4407-A634-AB1BE30A552F",
+            "name": "Ignored by Security Policy"
+          },
+          "disregardIfFixable": false,
+          "created": "2021-06-13T09:33:57.318Z"
+        }
+      }
+    },
+    {
+      "title": "Regular Expression Denial of Service (ReDoS)",
+      "credit": [
+        "Cristian-Alexandru Staicu"
+      ],
+      "moduleName": "marked",
+      "packageName": "marked",
+      "language": "js",
+      "packageManager": "npm",
+      "description": "## Overview\n[`marked`](https://www.npmjs.com/package/marked) is a full-featured markdown parser and compiler.\n\nAffected versions of this package are vulnerable to Regular expression Denial of Service (ReDoS) attacks when parsing the input markdown content (1,000 characters costs around 6 seconds matching time).\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Many Regular Expression implementations may reach extreme situations that cause them to work very slowly (exponentially related to input size), allowing an attacker to exploit this and can cause the program to enter these extreme situations by using a specially crafted input and cause the service to excessively consume CPU, resulting in a Denial of Service.\n\nYou can read more about `Regular Expression Denial of Service (ReDoS)` on our [blog](https://snyk.io/blog/redos-and-catastrophic-backtracking/).\n\n## Remediation\nThere is no fix version yet. At time of writing, latest version is `0.3.6`.\n\n## References\n- [Github Issue](https://github.com/chjj/marked/issues/937)\n",
+      "identifiers": {
+        "NSP": 531,
+        "CWE": [
+          "CWE-400"
+        ],
+        "CVE": [],
+        "ALTERNATIVE": [
+          "SNYK-JS-MARKED-10782"
+        ]
+      },
+      "semver": {
+        "vulnerable": "*",
+        "unaffected": "<0.0.0"
+      },
+      "cvssScore": 7.5,
+      "patches": [],
+      "severity": "high",
+      "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "disclosureTime": "2017-09-07T21:00:00.000Z",
+      "publicationTime": "2017-09-21T08:07:51.834Z",
+      "modificationTime": "2017-09-21T08:07:51.834Z",
+      "creationTime": "2017-09-21T08:07:51.834Z",
+      "id": "npm:marked:20170907",
+      "alternativeIds": [
+        "SNYK-JS-MARKED-10782"
+      ],
+      "from": [
+        "goof@0.0.3",
+        "marked@0.3.5"
+      ],
+      "upgradePath": [],
+      "version": "0.3.5",
+      "name": "marked",
+      "isUpgradable": false,
+      "isPatchable": false,
+      "__filename": "/Users/Josh/Sites/snyk/goof/node_modules/marked/package.json",
+      "parentDepType": "prod"
+    }
+  ],
+  "dependencyCount": 108
+}

--- a/test/fixtures/ignore-security-policy/vulns.json
+++ b/test/fixtures/ignore-security-policy/vulns.json
@@ -1,0 +1,284 @@
+{
+  "ok": false,
+  "vulnerabilities": [
+    {
+      "title": "Regular Expression Denial of Service",
+      "credit": [
+        "Adam Baldwin"
+      ],
+      "creationTime": "2016-01-19T23:24:51.834Z",
+      "modificationTime": "2016-01-19T23:24:51.834Z",
+      "publicationTime": "2016-01-19T21:51:35.396Z",
+      "description": "## Overview\nA [Regular expression Denial of Service (ReDoS)](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS) vulnerability exists in `hawk` package, affecting version 4.1.0 and below.\n\n\"The Regular expression Denial of Service (ReDoS) is a Denial of Service attack, that exploits the fact that most Regular Expression implementations may reach extreme situations that cause them to work very slowly (exponentially related to input size). An attacker can then cause a program using a Regular Expression to enter these extreme situations and then hang for a very long time.\" [1](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS)\n\n## References\n- https://github.com/hueniverse/hawk/issues/168\n- https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS\n",
+      "semver": {
+        "vulnerable": "<=3.1.2 || >= 4.0.0 <4.1.1",
+        "unaffected": ">3.1.2 < 4.0.0 || >=4.1.1"
+      },
+      "CVSSv3": "",
+      "severity": "low",
+      "identifiers": {
+        "CWE": [
+          "CWE-400"
+        ],
+        "CVE": [],
+        "NSP": 77
+      },
+      "patches": [
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/hawk/20160119/hawk_20160119_0_0_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+          ],
+          "version": "<4.1.1 >=4.0.0",
+          "modificationTime": "2016-01-20T12:51:35.396Z",
+          "comments": [],
+          "id": "patch:npm:hawk:20160119:0"
+        },
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/hawk/20160119/hawk_20160119_0_1_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+          ],
+          "version": "<4.0.0 >=3.0.0",
+          "modificationTime": "2016-01-20T12:51:35.396Z",
+          "comments": [],
+          "id": "patch:npm:hawk:20160119:1"
+        }
+      ],
+      "moduleName": "hawk",
+      "id": "npm:hawk:20160119",
+      "from": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14",
+        "request@2.64.0",
+        "hawk@3.1.0"
+      ],
+      "upgradePath": [
+        false,
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14",
+        "request@2.64.0",
+        "hawk@3.1.3"
+      ],
+      "version": "3.1.0",
+      "name": "hawk",
+      "__filename": "/Users/remy/Sites/snyk-tests/ignore/node_modules/sqlite/node_modules/sqlite3/node_modules/node-pre-gyp/node_modules/request/node_modules/hawk/package.json",
+      "bundled": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14"
+      ]
+    },
+    {
+      "title": "Regular Expression Denial of Service",
+      "credit": [
+        "Adam Baldwin"
+      ],
+      "creationTime": "2016-01-18T12:28:12.885Z",
+      "modificationTime": "2016-01-18T12:28:12.885Z",
+      "publicationTime": "2016-01-18T04:29:55.903Z",
+      "description": "## Overview\nA [Regular expression Denial of Service (ReDoS)](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS) vulnerability exists in `utc-millisec` validator of `is-my-json-valid` package, affecting version 2.12.3 and below.\n\n\"The Regular expression Denial of Service (ReDoS) is a Denial of Service attack, that exploits the fact that most Regular Expression implementations may reach extreme situations that cause them to work very slowly (exponentially related to input size). An attacker can then cause a program using a Regular Expression to enter these extreme situations and then hang for a very long time.\" [1](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS)\n\n## References\n- https://nodesecurity.io/advisories/76\n- https://github.com/mafintosh/is-my-json-valid/commit/eca4beb21e61877d76fdf6bea771f72f39544d9b\n- https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS\n\n\n",
+      "semver": {
+        "vulnerable": "<=2.12.3",
+        "unaffected": ">=2.12.4"
+      },
+      "CVSSv3": "",
+      "severity": "low",
+      "identifiers": {
+        "CWE": [
+          "CWE-400"
+        ],
+        "CVE": [],
+        "NSP": 76
+      },
+      "patches": [
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/is-my-json-valid/20160118/imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+          ],
+          "version": "<=2.12.3 >=2.0.3",
+          "modificationTime": "2016-01-21T12:51:35.396Z",
+          "comments": [],
+          "id": "patch:npm:is-my-json-valid:20160118:0"
+        },
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/is-my-json-valid/20160118/imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+          ],
+          "version": "<2.0.3 >=1.3.4",
+          "modificationTime": "2016-01-21T12:51:35.396Z",
+          "comments": [],
+          "id": "patch:npm:is-my-json-valid:20160118:1"
+        }
+      ],
+      "moduleName": "is-my-json-valid",
+      "id": "npm:is-my-json-valid:20160118",
+      "from": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14",
+        "request@2.64.0",
+        "har-validator@1.8.0",
+        "is-my-json-valid@2.12.2"
+      ],
+      "upgradePath": [
+        false,
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14",
+        "request@2.64.0",
+        "har-validator@1.8.0",
+        "is-my-json-valid@2.12.4"
+      ],
+      "version": "2.12.2",
+      "name": "is-my-json-valid",
+      "__filename": "/Users/remy/Sites/snyk-tests/ignore/node_modules/sqlite/node_modules/sqlite3/node_modules/node-pre-gyp/node_modules/request/node_modules/har-validator/node_modules/is-my-json-valid/package.json",
+      "bundled": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14"
+      ]
+    },
+    {
+      "title": "Symlink Arbitrary File Overwrite",
+      "credit": [
+        "Tim Cuthbertson"
+      ],
+      "creationTime": "2015-11-06T02:09:36.182Z",
+      "modificationTime": "2015-11-06T02:09:36.182Z",
+      "publicationTime": "2015-11-03T07:15:12.900Z",
+      "description": "## Overview\nThe [`tar`](https://www.npmjs.com/package/tar) module prior to version 2.0.0 does not properly normalize symbolic links pointing to targets outside the extraction root. As a result, packages may hold symbolic links to parent and sibling directories and overwrite those files when the package is extracted.\n\n## Remediation\nUpgrade to version 2.0.0 or greater. \nIf a direct dependency update is not possible, use [`snyk wizard`](https://snyk.io/documentation/#wizard) to patch this vulnerability.\n\n## References\n- https://nodesecurity.io/advisories/57\n- https://github.com/npm/node-tar/commit/a5337a6cd58a2d800fc03b3781a25751cf459f28\n- https://github.com/npm/npm/releases/tag/v2.7.5\n",
+      "semver": {
+        "vulnerable": "<2.0.0",
+        "unaffected": ">=2.0.0"
+      },
+      "CVSSv3": "",
+      "severity": "high",
+      "identifiers": {
+        "CWE": [],
+        "CVE": [],
+        "NSP": 57
+      },
+      "patches": [
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/tar/20151103/tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+          ],
+          "version": "<2.0.0 >=0.1.13",
+          "modificationTime": "2015-11-17T09:29:10.000Z",
+          "comments": [
+            "https://github.com/npm/node-tar/commit/a5337a6cd58a2d800fc03b3781a25751cf459f28.patch"
+          ],
+          "id": "patch:npm:tar:20151103:0"
+        },
+        {
+          "urls": [
+            "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/tar/20151103/tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+          ],
+          "version": "<0.1.13 >0.0.1",
+          "modificationTime": "2015-11-17T09:29:10.000Z",
+          "comments": [
+            "https://github.com/npm/node-tar/commit/a5337a6cd58a2d800fc03b3781a25751cf459f28.patch"
+          ],
+          "id": "patch:npm:tar:20151103:1"
+        }
+      ],
+      "moduleName": "tar",
+      "id": "npm:tar:20151103",
+      "from": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14",
+        "tar-pack@2.0.0",
+        "tar@0.1.20"
+      ],
+      "upgradePath": [
+        false,
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.15",
+        "tar-pack@3.1.0",
+        "tar@2.2.1"
+      ],
+      "version": "0.1.20",
+      "name": "tar",
+      "__filename": "/Users/remy/Sites/snyk-tests/ignore/node_modules/sqlite/node_modules/sqlite3/node_modules/node-pre-gyp/node_modules/tar-pack/node_modules/tar/package.json",
+      "bundled": [
+        "ignore@1.0.0",
+        "sqlite@0.0.2",
+        "sqlite3@3.1.1",
+        "node-pre-gyp@0.6.14"
+      ],
+      "securityPolicyMetaData": {
+        "ignore": {
+          "path": [
+            "*"
+          ],
+          "reason": "",
+          "reasonType": "wont-fix",
+          "source": "security-policy",
+          "ignoredBy": {
+            "id": "22A6B3BE-ABEF-4407-A634-AB1BE30A552F",
+            "name": "Ignored by Security Policy"
+          },
+          "disregardIfFixable": false,
+          "created": "2021-06-13T09:33:57.318Z"
+        }
+      }
+    },
+    {
+      "title": "Regular Expression Denial of Service (ReDoS)",
+      "credit": [
+        "Cristian-Alexandru Staicu"
+      ],
+      "moduleName": "marked",
+      "packageName": "marked",
+      "language": "js",
+      "packageManager": "npm",
+      "description": "## Overview\n[`marked`](https://www.npmjs.com/package/marked) is a full-featured markdown parser and compiler.\n\nAffected versions of this package are vulnerable to Regular expression Denial of Service (ReDoS) attacks when parsing the input markdown content (1,000 characters costs around 6 seconds matching time).\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Many Regular Expression implementations may reach extreme situations that cause them to work very slowly (exponentially related to input size), allowing an attacker to exploit this and can cause the program to enter these extreme situations by using a specially crafted input and cause the service to excessively consume CPU, resulting in a Denial of Service.\n\nYou can read more about `Regular Expression Denial of Service (ReDoS)` on our [blog](https://snyk.io/blog/redos-and-catastrophic-backtracking/).\n\n## Remediation\nThere is no fix version yet. At time of writing, latest version is `0.3.6`.\n\n## References\n- [Github Issue](https://github.com/chjj/marked/issues/937)\n",
+      "identifiers": {
+        "NSP": 531,
+        "CWE": [
+          "CWE-400"
+        ],
+        "CVE": [],
+        "ALTERNATIVE": [
+          "SNYK-JS-MARKED-10782"
+        ]
+      },
+      "semver": {
+        "vulnerable": "*",
+        "unaffected": "<0.0.0"
+      },
+      "cvssScore": 7.5,
+      "patches": [],
+      "severity": "high",
+      "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "disclosureTime": "2017-09-07T21:00:00.000Z",
+      "publicationTime": "2017-09-21T08:07:51.834Z",
+      "modificationTime": "2017-09-21T08:07:51.834Z",
+      "creationTime": "2017-09-21T08:07:51.834Z",
+      "id": "npm:marked:20170907",
+      "alternativeIds": [
+        "SNYK-JS-MARKED-10782"
+      ],
+      "from": [
+        "goof@0.0.3",
+        "marked@0.3.5"
+      ],
+      "upgradePath": [],
+      "version": "0.3.5",
+      "name": "marked",
+      "isUpgradable": false,
+      "isPatchable": false,
+      "__filename": "/Users/Josh/Sites/snyk/goof/node_modules/marked/package.json",
+      "parentDepType": "prod"
+    }
+  ],
+  "dependencyCount": 108
+}

--- a/test/unit/filter-ignore.test.js
+++ b/test/unit/filter-ignore.test.js
@@ -80,3 +80,160 @@ test('ignored vulns do not turn up in tests', function (t) {
     .catch(t.threw)
     .then(t.end);
 });
+
+test('vulns filtered by security policy ignores', function (t) {
+  const fixturesSecPolicy = __dirname + '/../fixtures/ignore-security-policy';
+  const vulns = require(fixturesSecPolicy + '/vulns.json');
+
+  policy
+    .load(fixtures)
+    .then(function () {
+      const start = vulns.vulnerabilities.length;
+      t.ok(start > 0, `we have ${start} vulns to start with`);
+
+      const filtered = [];
+
+      vulns.vulnerabilities = ignore({}, vulns.vulnerabilities, filtered);
+
+      t.equal(
+        start - 1,
+        vulns.vulnerabilities.length,
+        `vulns that were not filtered: ${vulns.vulnerabilities.length}`
+      );
+      t.equal(1, filtered.length, `${filtered.length} vuln filtered`);
+
+      const expected = {
+        'npm:tar:20151103': [
+          {
+            reason: '',
+            reasonType: 'wont-fix',
+            source: 'security-policy',
+            ignoredBy: {
+              id: '22A6B3BE-ABEF-4407-A634-AB1BE30A552F',
+              name: 'Ignored by Security Policy',
+            },
+            created: '2021-06-13T09:33:57.318Z',
+            disregardIfFixable: false,
+            path: ['*'],
+          },
+        ],
+      };
+
+      const actual = filtered.reduce(function (actual, vuln) {
+        actual[vuln.id] = vuln.filtered.ignored;
+        return actual;
+      }, {});
+
+      t.same(actual, expected, 'filtered vuln includes ignore rules');
+    })
+    .catch(t.threw)
+    .then(t.end);
+});
+
+test('vulns filtered by security policy and config ignores', function (t) {
+  const fixturesSecPolicy = __dirname + '/../fixtures/ignore-security-policy';
+  const vulns = require(fixturesSecPolicy + '/vulns-security-metadata.json');
+
+  policy
+  .load(fixtures)
+  .then(function (config) {
+    const start = vulns.vulnerabilities.length;
+    t.ok(start > 0, `we have ${start} vulns to start with`);
+
+    const filtered = [];
+
+    vulns.vulnerabilities = ignore(config.ignore, vulns.vulnerabilities, filtered);
+
+    t.equal(
+      start - 4,
+      vulns.vulnerabilities.length,
+      `vulns that were not filtered: 0`
+    );
+
+    t.equal(filtered.length, 4, `${filtered.length} vuln filtered`);
+
+    const expected = {
+      'npm:hawk:20160119': [
+        {
+          reason: 'hawk got bumped',
+          expires: '2116-03-01T14:30:04.136Z',
+          path: ['sqlite', 'sqlite3', 'node-pre-gyp', 'request', 'hawk'],
+        },
+      ],
+      'npm:is-my-json-valid:20160118': [
+        {
+          reason: 'dev tool',
+          expires: '2116-03-01T14:30:04.136Z',
+          path: [
+            'sqlite',
+            'sqlite3',
+            'node-pre-gyp',
+            'request',
+            'har-validator',
+            'is-my-json-valid',
+          ],
+        },
+      ],
+      'npm:tar:20151103': [
+        {
+          reason: '',
+          reasonType: 'wont-fix',
+          source: 'security-policy',
+          ignoredBy: {
+            id: '22A6B3BE-ABEF-4407-A634-AB1BE30A552F',
+            name: 'Ignored by Security Policy',
+          },
+          created: '2021-06-13T09:33:57.318Z',
+          disregardIfFixable: false,
+          path: ['*'],
+        },
+      ],
+      'npm:marked:20170907': [
+        {
+          reason: 'none given',
+          disregardIfFixable: true,
+          path: ['*'],
+        },
+      ],
+    };
+
+    const actual = filtered.reduce(function (actual, vuln) {
+      actual[vuln.id] = vuln.filtered.ignored;
+      return actual;
+    }, {});
+
+    t.same(actual, expected, 'filtered vuln includes ignore rules from security policies and config');
+  })
+  .catch(t.threw)
+  .then(t.end)
+});
+
+test('does not accept incomplete security policy to ignore vulns', function (t) {
+  const fixturesSecPolicy = __dirname + '/../fixtures/ignore-security-policy';
+  const vulns = require(fixturesSecPolicy + '/vulns-incomplete-security-metadata.json');
+
+  policy
+    .load(fixtures)
+    .then(function (config) {
+      const start = vulns.vulnerabilities.length;
+      t.ok(vulns.vulnerabilities.length > 0, 'we have vulns to start with');
+
+      const filtered = [];
+
+      vulns.vulnerabilities = ignore(
+        config.ignore,
+        vulns.vulnerabilities,
+        filtered
+      );
+
+      // should strip 4
+      t.equal(
+        start - 4,
+        vulns.vulnerabilities.length,
+        'vulns that were not filtered: ' + vulns.vulnerabilities.length
+      );
+      t.equal(4, filtered.length, '4 vulns filtered');
+    })
+    .catch(t.threw)
+    .then(t.end);
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Implementing new source of ignore data from security policies.
In case issue was enriched with `securityPolicyMetaData.ignore` this issue should apply ignore from security policy only and skip other ignores. Also ignore object will contain few more fields and will look like:

```js
'npm:tar:20151103': [
  {
    reason: '',
    reasonType: 'wont-fix',
    source: 'security-policy',
    ignoredBy: {
      id: '22A6B3BE-ABEF-4407-A634-AB1BE30A552F',
      name: 'Ignored by Security Policy',
    },
    created: '2021-06-13T09:33:57.318Z',
    disregardIfFixable: false,
    path: ['*'],
  },
]
```

In other case old logic should be applied.

#### How should this be manually tested?

1. Checkout this branch locally and use it as local source for `snyk-policy` in registry
2. Enable ignore action FF in registry
3. Create new policy with the ignore action
4. Re-test project from the org where you attached new policy
5. You should see issues that match policy ignored

**Alternatively to step 1** you can open `node_modules/snyk-policy/lib/filter/ignore.js` and replace it with the contents of same file from this PR. And restart registry
