### PR TITLE
feat: optional "exact" ignore behaviour

### DIFF
--- a/lib/filter/ignore.js
+++ b/lib/filter/ignore.js
@@ -7,7 +7,12 @@ const matchToRule = require('../match').matchToRule;
 // given an ignore ruleset (parsed from the .snyk yaml file) and a array of
 // vulnerabilities, return the vulnerabilities that *are not* ignored
 // see http://git.io/vCHmV for example of what ignore structure looks like
-function filterIgnored(ignore, vuln, filtered) {
+function filterIgnored(
+  ignore,
+  vuln,
+  filtered,
+  matchStrategy = 'packageManager'
+) {
   if (!ignore) {
     return vuln;
   }
@@ -75,7 +80,7 @@ function filterIgnored(ignore, vuln, filtered) {
           }
 
           // first check if the path is a match on the rule
-          const pathMatch = matchToRule(vuln, rule);
+          const pathMatch = matchToRule(vuln, rule, matchStrategy);
 
           if (pathMatch && expires && expires < now) {
             debug('%s vuln rule has expired (%s)', vuln.id, expires);

--- a/lib/filter/index.js
+++ b/lib/filter/index.js
@@ -6,7 +6,7 @@ const patch = require('./patch');
 const notes = require('./notes');
 
 // warning: mutates vulns
-function filter(vulns, policy, root) {
+function filter(vulns, policy, root, matchStrategy = 'packageManager') {
   if (!root) {
     root = process.cwd();
   }
@@ -24,7 +24,8 @@ function filter(vulns, policy, root) {
   vulns.vulnerabilities = ignore(
     policy.ignore,
     vulns.vulnerabilities,
-    filtered.ignore
+    filtered.ignore,
+    matchStrategy
   );
 
   vulns.vulnerabilities = patch(

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,8 +29,13 @@ function defaultFilename() {
 }
 
 function attachMethods(policy) {
-  policy.filter = function (vulns, root) {
-    return filter(vulns, policy, root || path.dirname(policy.__filename));
+  policy.filter = function (vulns, root, matchStrategy = 'packageManager') {
+    return filter(
+      vulns,
+      policy,
+      root || path.dirname(policy.__filename),
+      matchStrategy
+    );
   };
   policy.save = save.bind(null, policy);
   policy.toString = parse.export.bind(null, policy);

--- a/lib/match.js
+++ b/lib/match.js
@@ -105,13 +105,17 @@ function matchPath(from, path) {
   return res;
 }
 
-function matchToRule(vuln, rule) {
+function matchToRule(vuln, rule, matchStrategy = 'packageManager') {
   return Object.keys(rule).some(function (path) {
-    return matchToSingleRule(vuln, path);
+    return matchToSingleRule(vuln, path, matchStrategy);
   });
 }
 
-function matchToSingleRule(vuln, path) {
+function matchToSingleRule(vuln, path, matchStrategy) {
+  if (matchStrategy === 'exact') {
+    return matchExactWithStars(vuln, path);
+  }
+
   // check for an exact match
   let pathMatch = false;
   const from = vuln.from.slice(1);
@@ -123,6 +127,25 @@ function matchToSingleRule(vuln, path) {
   }
 
   return pathMatch;
+}
+
+function matchExactWithStars(vuln, path) {
+  const parts = path.split(' > ');
+  if (parts[parts.length - 1] === '*') {
+    const paddingLength = vuln.from.length - parts.length;
+    for (let i = 0; i < paddingLength; i++) {
+      parts.push('*');
+    }
+  }
+  if (parts.length !== vuln.from.length) {
+    return false;
+  }
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i] !== vuln.from[i] && parts[i] !== '*') {
+      return false;
+    }
+  }
+  return true;
 }
 
 function getByVuln(policy, vuln) {

--- a/test/fixtures/ignore-exact/.snyk
+++ b/test/fixtures/ignore-exact/.snyk
@@ -1,0 +1,8 @@
+# vi: syntax=yaml
+version: v1.19.0
+ignore:
+  a-vuln:
+    - 'file.json > foo > bar':
+        reason: None Given
+        created: 2021-07-26T13:09:08.459Z
+patch: {}

--- a/test/unit/filter-ignore.test.js
+++ b/test/unit/filter-ignore.test.js
@@ -1,3 +1,4 @@
+const cloneDeep = require('lodash.clonedeep');
 const test = require('tap').test;
 const fixtures = __dirname + '/../fixtures/ignore';
 const vulns = require(fixtures + '/vulns.json');
@@ -242,6 +243,37 @@ test('does not accept incomplete security policy to ignore vulns', function (t) 
         'vulns that were not filtered: ' + vulns.vulnerabilities.length
       );
       t.equal(4, filtered.length, '4 vulns filtered');
+    })
+    .catch(t.threw)
+    .then(t.end);
+});
+
+test('filters vulnerabilities by exact match', function (t) {
+  const vulns = {
+    vulnerabilities: [
+      {
+        id: 'a-vuln',
+        from: ['dir/file.json', 'foo', 'bar'],
+      },
+      {
+        id: 'a-vuln',
+        from: ['file.json', 'foo', 'bar'],
+      },
+      {
+        id: 'another-vuln',
+        from: ['file.json', 'foo', 'bar'],
+      },
+    ],
+  };
+
+  const expected = cloneDeep(vulns);
+  expected.vulnerabilities.splice(1, 1);
+
+  policy
+    .load(__dirname + '/../fixtures/ignore-exact')
+    .then(function (config) {
+      const filtered = config.filter(vulns, undefined, 'exact');
+      t.same(filtered.vulnerabilities, expected.vulnerabilities);
     })
     .catch(t.threw)
     .then(t.end);

--- a/test/unit/filter-ignore.test.js
+++ b/test/unit/filter-ignore.test.js
@@ -135,82 +135,91 @@ test('vulns filtered by security policy and config ignores', function (t) {
   const vulns = require(fixturesSecPolicy + '/vulns-security-metadata.json');
 
   policy
-  .load(fixtures)
-  .then(function (config) {
-    const start = vulns.vulnerabilities.length;
-    t.ok(start > 0, `we have ${start} vulns to start with`);
+    .load(fixtures)
+    .then(function (config) {
+      const start = vulns.vulnerabilities.length;
+      t.ok(start > 0, `we have ${start} vulns to start with`);
 
-    const filtered = [];
+      const filtered = [];
 
-    vulns.vulnerabilities = ignore(config.ignore, vulns.vulnerabilities, filtered);
+      vulns.vulnerabilities = ignore(
+        config.ignore,
+        vulns.vulnerabilities,
+        filtered
+      );
 
-    t.equal(
-      start - 4,
-      vulns.vulnerabilities.length,
-      `vulns that were not filtered: 0`
-    );
+      t.equal(
+        start - 4,
+        vulns.vulnerabilities.length,
+        `vulns that were not filtered: 0`
+      );
 
-    t.equal(filtered.length, 4, `${filtered.length} vuln filtered`);
+      t.equal(filtered.length, 4, `${filtered.length} vuln filtered`);
 
-    const expected = {
-      'npm:hawk:20160119': [
-        {
-          reason: 'hawk got bumped',
-          expires: '2116-03-01T14:30:04.136Z',
-          path: ['sqlite', 'sqlite3', 'node-pre-gyp', 'request', 'hawk'],
-        },
-      ],
-      'npm:is-my-json-valid:20160118': [
-        {
-          reason: 'dev tool',
-          expires: '2116-03-01T14:30:04.136Z',
-          path: [
-            'sqlite',
-            'sqlite3',
-            'node-pre-gyp',
-            'request',
-            'har-validator',
-            'is-my-json-valid',
-          ],
-        },
-      ],
-      'npm:tar:20151103': [
-        {
-          reason: '',
-          reasonType: 'wont-fix',
-          source: 'security-policy',
-          ignoredBy: {
-            id: '22A6B3BE-ABEF-4407-A634-AB1BE30A552F',
-            name: 'Ignored by Security Policy',
+      const expected = {
+        'npm:hawk:20160119': [
+          {
+            reason: 'hawk got bumped',
+            expires: '2116-03-01T14:30:04.136Z',
+            path: ['sqlite', 'sqlite3', 'node-pre-gyp', 'request', 'hawk'],
           },
-          created: '2021-06-13T09:33:57.318Z',
-          disregardIfFixable: false,
-          path: ['*'],
-        },
-      ],
-      'npm:marked:20170907': [
-        {
-          reason: 'none given',
-          disregardIfFixable: true,
-          path: ['*'],
-        },
-      ],
-    };
+        ],
+        'npm:is-my-json-valid:20160118': [
+          {
+            reason: 'dev tool',
+            expires: '2116-03-01T14:30:04.136Z',
+            path: [
+              'sqlite',
+              'sqlite3',
+              'node-pre-gyp',
+              'request',
+              'har-validator',
+              'is-my-json-valid',
+            ],
+          },
+        ],
+        'npm:tar:20151103': [
+          {
+            reason: '',
+            reasonType: 'wont-fix',
+            source: 'security-policy',
+            ignoredBy: {
+              id: '22A6B3BE-ABEF-4407-A634-AB1BE30A552F',
+              name: 'Ignored by Security Policy',
+            },
+            created: '2021-06-13T09:33:57.318Z',
+            disregardIfFixable: false,
+            path: ['*'],
+          },
+        ],
+        'npm:marked:20170907': [
+          {
+            reason: 'none given',
+            disregardIfFixable: true,
+            path: ['*'],
+          },
+        ],
+      };
 
-    const actual = filtered.reduce(function (actual, vuln) {
-      actual[vuln.id] = vuln.filtered.ignored;
-      return actual;
-    }, {});
+      const actual = filtered.reduce(function (actual, vuln) {
+        actual[vuln.id] = vuln.filtered.ignored;
+        return actual;
+      }, {});
 
-    t.same(actual, expected, 'filtered vuln includes ignore rules from security policies and config');
-  })
-  .catch(t.threw)
-  .then(t.end)
+      t.same(
+        actual,
+        expected,
+        'filtered vuln includes ignore rules from security policies and config'
+      );
+    })
+    .catch(t.threw)
+    .then(t.end);
 });
 
 test('does not accept incomplete security policy to ignore vulns', function (t) {
   const fixturesSecPolicy = __dirname + '/../fixtures/ignore-security-policy';
-  const vulns = require(fixturesSecPolicy + '/vulns-incomplete-security-metadata.json');
+  const vulns = require(fixturesSecPolicy +
+    '/vulns-incomplete-security-metadata.json');
 
   policy
     .load(fixtures)


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Add a flag to the `ignore` method signature to opt-in to "simple"
path-matching behaviour.

The following vulnerability path: `['foo', 'bar', 'baz']` will be
matched by the following ignore rules under this behaviour:

- 'foo > bar > baz'
- 'foo > *'
- '*'

Under the default matching behaviour, there are some quirks that appear
specific to package manager use cases:

- The first element of vulnerabilities paths is sliced off
- If the path (minus the first element) "contains" the rule as a
  substring, it will match. For example: the rule `file.json` will match
  the path `["dir/file.json"]`.
- Attempts to parse paths as packages, URLs, or git objects.

The Snyk infrastructure-as-code use-case breaks under these default
behaviours, but we still want to use the policy library in order to not
reimplement loading and parsing of the policy file.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

Snyk IaC are adding support for `.snyk` ignore policies, but in order to adapt this feature to our domain we are proposing to use different semantics for the ignore rules. [This doc](https://docs.google.com/document/d/1FDgtH_KKfqyyBlpSXwLvpdosXqx7dctw8DWsgfkT8kk/edit#) contains the detail, but here is a summary:

Users can ignore all instances of an IaC issue:

```yaml
version: v1.19.0
ignore:
  SNYK-CC-K8S-1:
    - '*':
        reason: None Given
        expires: 2021-08-26T08:40:35.249Z
        created: 2021-07-27T08:40:35.251Z
```

Ignores can be scoped to individual files:

```yaml
version: v1.19.0
ignore:
  SNYK-CC-K8S-1:
    - 'staging/deployment.yaml > *':
        reason: None Given
        expires: 2021-08-26T08:40:35.249Z
        created: 2021-07-27T08:40:35.251Z
```

And finally, ignores can be scoped to individual instances in the IaC file's "resource path":

```yaml
version: v1.19.0
ignore:
  SNYK-CC-K8S-1:
    - staging/deployment.yaml > [DocId:1] > spec > template > spec > containers[web] > securityContext > privileged':
        reason: None Given
        expires: 2021-08-26T08:40:35.249Z
        created: 2021-07-27T08:40:35.251Z
```

When integrating this policy library with the IaC flows in the Snyk CLI, I noticed some edge cases emerge. Most of them can be summarised as "inexact matching" occurring. For example, the path rule `deployment.yaml` would match any vulnerability in a file named `deployment.yaml`, even if it was in a subdirectory.

https://github.com/snyk/snyk/pull/2134 demonstrates our almost-complete CLI ignores feature. The last commit on that PR, https://github.com/snyk/snyk/pull/2134/commits/e851f9aa6139bf81de608189d8f93c1b4c1321bd, adds a failing test demonstrating the sort of edge-case I'm talking about, which is fixed when I npm-link in this PR branch.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CC-990

#### Screenshots


#### Additional questions
