### PR TITLE
Make snyk-policy webpack compatible

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -228,14 +228,3 @@ function save(object, root, spinner) {
     })
     .then(spinner.clear(lbl));
 }
-
-/* istanbul ignore if */
-if (!module.parent) {
-  load(process.argv[2])
-    .then(function (res) {
-      console.log(JSON.stringify(res, '', 2));
-    })
-    .catch(function (e) {
-      console.log(e.stack);
-    });
-}

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -1,8 +1,8 @@
-const path = require('path');
 const cloneDeep = require('lodash.clonedeep');
 const semver = require('semver');
 const yaml = require('js-yaml');
 const addComments = require('./add-comments');
+const { version: versionFromPackageJson } = require('../../package.json');
 
 module.exports = {
   import: imports,
@@ -66,11 +66,8 @@ function exports(policy) {
 }
 
 function version() {
-  const filename = path.resolve(__dirname, '..', '..', 'package.json');
-  const version = require(filename).version;
-
-  if (version && version !== '0.0.0') {
-    return 'v' + version;
+  if (versionFromPackageJson && versionFromPackageJson !== '0.0.0') {
+    return 'v' + versionFromPackageJson;
   }
 
   return 'v1.0.0';


### PR DESCRIPTION
This PR is triggered by a work on Snyk CLI and its bundling with Webpack snyk/snyk#2105. Webpack can't resolve the dynamic require we are using here. Switched to a top-level require, as `version()` is called on top-level as well.

Also removed the self-execution functionality using module.parent. This was producing an empty console.log in some scenarios. Library is also not used self-executing/cli context