### PR TITLE
chore: update node version to latest of each

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
   docker-node:
     parameters:
       version:
-        default: '12.22.1'
+        default: '14.19.0'
         type: string
     docker:
       - image: cimg/node:<<parameters.version>>
@@ -54,7 +54,7 @@ jobs:
     <<: *defaults
     parameters:
       version:
-        default: '12.22.1'
+        default: '14.19.0'
         type: string
     executor:
       name: docker-node
@@ -110,9 +110,9 @@ workflows:
           matrix:
             parameters:
               version:
-                - 8.17.0
-                - 10.24.1
-                - 12.22.1
+                - 12.22.10
+                - 14.19.0
+                - 16.24.0
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ workflows:
               version:
                 - 12.22.10
                 - 14.19.0
-                - 16.24.0
+                - 16.14.0
           filters:
             branches:
               ignore:


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Updates the Node Version in Circle CI configurations. That is because the Semantic version does not support versions lower than as described in errors.

```
npx: installed 522 in 10.004s
[semantic-release]: node version >=16 || ^14.17 is required. Found v12.22.1.
```
