### PR TITLE
feature: support add-exclude

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 * @snyk/narwhal
+lib/add-exclude.js @snyk/tundra

--- a/lib/add-exclude.js
+++ b/lib/add-exclude.js
@@ -1,0 +1,21 @@
+module.exports = addExclude;
+
+function addExclude(policy, pattern, group='global') {
+  if (!isPatternGroupValid(group)) {
+    throw new Error('invalid file pattern-group');
+  }
+
+  policy.exclude = policy.exclude ? policy.exclude: {};
+
+  const patterns = policy.exclude[group] ? policy.exclude[group]: [];
+
+  if (patterns.includes(pattern)) {
+    return; // Exit early, to prevent duplication
+  }
+
+  policy.exclude[group] = [...patterns, pattern];
+}
+
+function isPatternGroupValid(group) {
+  return ['global', 'code'].includes(group);
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ const parse = require('./parser');
 const tryRequire = require('snyk-try-require');
 const filter = require('./filter');
 const add = require('./add');
+const addExclude = require('./add-exclude');
 
 module.exports = {
   filter: filter,
@@ -16,6 +17,7 @@ module.exports = {
   matchToRule: match.matchToRule,
   loadFromText: loadFromText,
   add: add,
+  addExclude: addExclude,
   create: create,
 };
 
@@ -43,6 +45,7 @@ function attachMethods(policy) {
   policy.add = add.bind(null, policy);
   policy.addIgnore = add.bind(null, policy, 'ignore');
   policy.addPatch = add.bind(null, policy, 'patch');
+  policy.addExclude = addExclude.bind(null, policy);
   return policy;
 }
 

--- a/test/unit/add-exclude.test.js
+++ b/test/unit/add-exclude.test.js
@@ -1,0 +1,89 @@
+const test = require('tap').test;
+const create = require('../../lib').create;
+
+test('use of invalid file pattern-group throws errors', function (t) {
+  return create().then(function (policy) {
+    t.throws(
+      function () {
+        const invalidGroup = 'unmanaged';
+        policy.addExclude('./deps/*.ts', invalidGroup);
+      },
+      'invalid file pattern-group'
+    );
+  });
+});
+
+test('add a new file pattern to default group', function (t) {
+  return create().then(function (policy) {
+    t.doesNotThrow(
+      function () {
+        policy.addExclude('./deps/*.ts');
+
+        const expected = { 'global': ['./deps/*.ts'] };
+
+        t.deepEqual( policy.exclude, expected, 'pattern added');
+      },
+    );
+  });
+});
+
+test('add a new file pattern to global-group', function (t) {
+  return create().then(function (policy) {
+    t.doesNotThrow(
+      function () {
+        const validGroup = 'global';
+        policy.addExclude('./deps/*.ts', validGroup);
+
+        const expected = { 'global': ['./deps/*.ts'] };
+
+        t.deepEqual( policy.exclude, expected, 'pattern added');
+      },
+    );
+  });
+});
+
+test('add a new file pattern to code-group', function (t) {
+  return create().then(function (policy) {
+    t.doesNotThrow(
+      function () {
+        const validGroup = 'code';
+        policy.addExclude('./deps/*.ts', validGroup);
+
+        const expected = { 'code': ['./deps/*.ts'] };
+
+        t.deepEqual( policy.exclude, expected, 'pattern added');
+      },
+    );
+  });
+});
+
+test('add two new unique file pattern to a group', function (t) {
+  return create().then(function (policy) {
+    t.doesNotThrow(
+      function () {
+        policy.addExclude('./deps/*.ts');
+        policy.addExclude('./vendor/*.ts');
+        const expected = { 'global': ['./deps/*.ts', './vendor/*.ts'] };
+
+        t.deepEqual(policy.exclude, expected, 'pattern added');
+      },
+    );
+  });
+});
+
+test('ignore already existing patterns', function (t) {
+  return create().then(function (policy) {
+    t.doesNotThrow(
+      function () {
+        policy.addExclude('./deps/*.ts');
+        policy.addExclude('./deps/*.ts');
+        policy.addExclude('./vendor/*.ts');
+        policy.addExclude('./deps/*.ts');
+
+        const expected = { 'global': ['./deps/*.ts', './vendor/*.ts'] };
+
+        t.deepEqual(policy.exclude, expected, 'pattern added');
+      },
+    );
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What it does

Add function to provide file paths to be added to exclude-section in
policy-files.

- Add function addExclude, to add file path-patterns to a policy object.
- Add validation of the exclude-group:
  - global -- for files to ignore by unmanaged, and Snyk Code
  - code -- for files being ignored by Snyk Code
- Add logic to prevent duplication of patterns within the same group.

#### How should this be manually tested?

In an upcoming release of the CLI, it will be used by following command:

`snyk ignore --file-path='./vendor/*.ts' --file-path-group='global'`