### PR TITLE
support expiry/creation and reason for excluded paths

### DIFF
--- a/lib/add-exclude.js
+++ b/lib/add-exclude.js
@@ -1,21 +1,25 @@
 module.exports = addExclude;
 
-function addExclude(policy, pattern, group='global') {
+function addExclude(policy, pattern, group = 'global', options = {}) {
   if (!isPatternGroupValid(group)) {
     throw new Error('invalid file pattern-group');
   }
 
-  policy.exclude = policy.exclude ? policy.exclude: {};
+  policy.exclude = policy.exclude || {};
 
-  const patterns = policy.exclude[group] ? policy.exclude[group]: [];
+  let patterns = policy.exclude[group] || [];
 
-  if (patterns.includes(pattern)) {
-    return; // Exit early, to prevent duplication
-  }
+  // Remove duplicates
+  patterns = patterns.filter((p) => p !== pattern && !p[pattern]);
 
-  policy.exclude[group] = [...patterns, pattern];
+  options.created = new Date();
+
+  const entry =
+    !options.expires && !options.reason ? pattern : { [pattern]: options };
+
+  policy.exclude[group] = [...patterns, entry];
 }
 
 function isPatternGroupValid(group) {
-  return ['global', 'code'].includes(group);
+  return ['global', 'code', 'iac-drift'].includes(group);
 }

--- a/test/unit/add-exclude.test.js
+++ b/test/unit/add-exclude.test.js
@@ -3,87 +3,175 @@ const create = require('../../lib').create;
 
 test('use of invalid file pattern-group throws errors', function (t) {
   return create().then(function (policy) {
-    t.throws(
-      function () {
-        const invalidGroup = 'unmanaged';
-        policy.addExclude('./deps/*.ts', invalidGroup);
-      },
-      'invalid file pattern-group'
-    );
+    t.throws(function () {
+      const invalidGroup = 'unmanaged';
+      policy.addExclude('./deps/*.ts', invalidGroup);
+    }, 'invalid file pattern-group');
   });
 });
 
 test('add a new file pattern to default group', function (t) {
   return create().then(function (policy) {
-    t.doesNotThrow(
-      function () {
-        policy.addExclude('./deps/*.ts');
+    t.doesNotThrow(function () {
+      policy.addExclude('./deps/*.ts');
 
-        const expected = { 'global': ['./deps/*.ts'] };
+      const expected = { global: ['./deps/*.ts'] };
 
-        t.deepEqual( policy.exclude, expected, 'pattern added');
-      },
-    );
+      t.deepEqual(policy.exclude, expected, 'pattern added');
+    });
   });
 });
 
 test('add a new file pattern to global-group', function (t) {
   return create().then(function (policy) {
-    t.doesNotThrow(
-      function () {
-        const validGroup = 'global';
-        policy.addExclude('./deps/*.ts', validGroup);
+    t.doesNotThrow(function () {
+      const validGroup = 'global';
+      policy.addExclude('./deps/*.ts', validGroup);
 
-        const expected = { 'global': ['./deps/*.ts'] };
+      const expected = { global: ['./deps/*.ts'] };
 
-        t.deepEqual( policy.exclude, expected, 'pattern added');
-      },
-    );
+      t.deepEqual(policy.exclude, expected, 'pattern added');
+    });
   });
 });
 
 test('add a new file pattern to code-group', function (t) {
   return create().then(function (policy) {
-    t.doesNotThrow(
-      function () {
-        const validGroup = 'code';
-        policy.addExclude('./deps/*.ts', validGroup);
+    t.doesNotThrow(function () {
+      const validGroup = 'code';
+      policy.addExclude('./deps/*.ts', validGroup);
 
-        const expected = { 'code': ['./deps/*.ts'] };
+      const expected = { code: ['./deps/*.ts'] };
 
-        t.deepEqual( policy.exclude, expected, 'pattern added');
-      },
-    );
+      t.deepEqual(policy.exclude, expected, 'pattern added');
+    });
+  });
+});
+
+test('add a new file pattern to iac drift-group', function (t) {
+  return create().then(function (policy) {
+    t.doesNotThrow(function () {
+      const validGroup = 'iac-drift';
+
+      policy.addExclude('!aws_iam_*', validGroup);
+      policy.addExclude('aws_s3_bucket.*', validGroup);
+
+      const expected = {
+        [validGroup]: ['!aws_iam_*', 'aws_s3_bucket.*'],
+      };
+
+      t.deepEqual(policy.exclude, expected, 'pattern added to iac-drift');
+    });
   });
 });
 
 test('add two new unique file pattern to a group', function (t) {
   return create().then(function (policy) {
-    t.doesNotThrow(
-      function () {
-        policy.addExclude('./deps/*.ts');
-        policy.addExclude('./vendor/*.ts');
-        const expected = { 'global': ['./deps/*.ts', './vendor/*.ts'] };
+    t.doesNotThrow(function () {
+      policy.addExclude('./deps/*.ts');
+      policy.addExclude('./vendor/*.ts');
+      const expected = { global: ['./deps/*.ts', './vendor/*.ts'] };
 
-        t.deepEqual(policy.exclude, expected, 'pattern added');
-      },
-    );
+      t.deepEqual(policy.exclude, expected, 'pattern added');
+    });
   });
 });
 
-test('ignore already existing patterns', function (t) {
+test('replace duplicates patterns', function (t) {
   return create().then(function (policy) {
-    t.doesNotThrow(
-      function () {
-        policy.addExclude('./deps/*.ts');
-        policy.addExclude('./deps/*.ts');
-        policy.addExclude('./vendor/*.ts');
-        policy.addExclude('./deps/*.ts');
+    t.doesNotThrow(function () {
+      policy.addExclude('./deps/*.ts');
+      policy.addExclude('./deps/*.ts');
+      policy.addExclude('./vendor/*.ts');
+      policy.addExclude('./deps/*.ts');
 
-        const expected = { 'global': ['./deps/*.ts', './vendor/*.ts'] };
+      const expected = { global: ['./vendor/*.ts', './deps/*.ts'] };
 
-        t.deepEqual(policy.exclude, expected, 'pattern added');
-      },
-    );
+      t.deepEqual(policy.exclude, expected, 'pattern added');
+    });
+  });
+});
+
+test('add dates and reasons', function (t) {
+  return create().then(function (policy) {
+    t.doesNotThrow(function () {
+      policy.addExclude('./deps/*.ts', 'global', {
+        expires: '2092-12-24',
+        reason: 'incidents already fixed by user',
+      });
+
+      t.deepEqual(
+        policy.exclude['global'][0]['./deps/*.ts'].expires,
+        '2092-12-24',
+        'expires added with the correct format'
+      );
+      t.deepEqual(
+        policy.exclude['global'][0]['./deps/*.ts'].reason,
+        'incidents already fixed by user',
+        'reason added with the correct format'
+      );
+    });
+  });
+});
+
+test('replace existing objects', function (t) {
+  return create().then(function (policy) {
+    t.doesNotThrow(function () {
+      policy.addExclude('./deps/*.ts', 'global', {
+        expires: '2092-12-24',
+        reason: 'incidents already fixed by user',
+      });
+
+      policy.addExclude('./deps/*.ts', 'global', {
+        expires: '2192-12-24',
+        reason: 'it will never happen',
+      });
+
+      t.deepEqual(
+        policy.exclude['global'][0]['./deps/*.ts'].expires,
+        '2192-12-24',
+        'expire replaced'
+      );
+      t.deepEqual(
+        policy.exclude['global'][0]['./deps/*.ts'].reason,
+        'it will never happen',
+        'reason replaced'
+      );
+    });
+  });
+});
+
+test('only replace duplicates', function (t) {
+  return create().then(function (policy) {
+    t.doesNotThrow(function () {
+      policy.addExclude('./deps/*.ts', 'global', {
+        expires: '2092-12-24',
+        reason: 'incidents already fixed by user',
+      });
+
+      policy.addExclude('./vendor/*.go', 'global');
+
+      policy.addExclude('./deps/*.ts', 'global', {
+        expires: '2192-12-24',
+        reason: 'it will never happen',
+      });
+
+      t.deepEqual(
+        policy.exclude['global'][0],
+        './vendor/*.go',
+        'should keep unique pattern'
+      );
+
+      t.deepEqual(
+        policy.exclude['global'][1]['./deps/*.ts'].expires,
+        '2192-12-24',
+        'expire replaced'
+      );
+      t.deepEqual(
+        policy.exclude['global'][1]['./deps/*.ts'].reason,
+        'it will never happen',
+        'reason replaced'
+      );
+    });
   });
 });


### PR DESCRIPTION
 feat: support fields in excluded patterns

Add option to addExclude function, to add following fields to
exclude patterns:

- expiry
- reason

if those has been provided, creation date will also be added.

NOTE: If records already exists, they will be replaced by a new one.