### PR TITLE
feat: demunge 'exclude' rules

### DIFF
--- a/lib/parser/demunge.js
+++ b/lib/parser/demunge.js
@@ -5,15 +5,21 @@ function demunge(policy, apiRoot) {
     apiRoot = '';
   }
 
-  const res = ['ignore', 'patch'].reduce(function (acc, type) {
+  const res = ['ignore', 'patch', 'exclude'].reduce(function (acc, type) {
     acc[type] = policy[type]
       ? Object.keys(policy[type]).map(function (id) {
           const paths = policy[type][id].map(function (pathObj) {
+            if (type === 'exclude' && typeof pathObj === 'string') {
+              return {
+                path: pathObj,
+              };
+            }
+
             const path = Object.keys(pathObj).pop();
             const res = {
               path: path,
             };
-            if (type === 'ignore') {
+            if (type === 'ignore' || type === 'exclude') {
               res.reason = pathObj[path].reason;
               res.expires =
                 pathObj[path].expires && new Date(pathObj[path].expires);

--- a/test/fixtures/parsed.json
+++ b/test/fixtures/parsed.json
@@ -42,6 +42,26 @@
       }
     ]
   },
+  "exclude": {
+    "global:": [
+      {
+        "path/to/folder": {
+          "reason": "None given",
+          "expires": "2016-03-01T14:30:04.137Z"
+        }
+      },
+      {
+        "path/to/file.extension": {
+          "reason": "None given",
+          "expires": "2016-03-01T14:30:04.137Z"
+        }
+      }
+    ],
+    "code": [
+      "path/to/folder",
+      "path/to/file.extension"
+    ]
+  },
   "__filename": ".snyk",
   "__modified": "2016-03-03T18:06:17.000Z",
   "__created": "2016-03-03T18:06:17.000Z"

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -64,16 +64,35 @@ test('test unsupported version', function (t) {
 test('demunge', function (t) {
   const source = require(fixtures + '/parsed.json');
   const res = parser.demunge(source);
-  const ids = Object.keys(source.patch);
+  const patchIds = Object.keys(source.patch);
+  const ignoreIds = Object.keys(source.ignore);
+  const excludeIds = Object.keys(source.exclude);
   t.ok(Array.isArray(res.ignore), 'array');
   t.ok(Array.isArray(res.patch), 'array');
+  t.ok(Array.isArray(res.exclude), 'array');
   t.equal(res.patch.length, 2, 'two patched items');
+  t.equal(res.ignore.length, 3, 'three ignored items');
+  t.equal(res.exclude.length, 2, 'two excluded categories');
   t.deepEqual(
     res.patch.map(function (o) {
       return o.id;
     }),
-    ids,
-    'ids found in the right place'
+    patchIds,
+    'patch ids found in the right place'
+  );
+  t.deepEqual(
+    res.ignore.map(function (o) {
+      return o.id;
+    }),
+    ignoreIds,
+    'ignore ids found in the right place'
+  );
+  t.deepEqual(
+    res.exclude.map(function (o) {
+      return o.id;
+    }),
+    excludeIds,
+    'exclude ids found in the right place'
   );
   t.end();
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

- include the 'exclude' rules in the demunge implementation
- exclude might contain 2 categories/ids: global and code
- the entries for exclude.global/code might be simple paths (strings) or objects (including metadata like reason, creation/expiration dates).
