### PR TITLE
chore: bump dev deps

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-REQUEST-3361831:
+    - '*':
+        reason: Fix not yet merged - https://github.com/request/request/pull/3444
+        expires: 2023-07-21T21:12:33.979Z
+        created: 2023-04-21T21:12:33.983Z
+patch: {}

--- a/lib/filter/patch.js
+++ b/lib/filter/patch.js
@@ -69,7 +69,9 @@ function filterPatched(patched, vulns, cwd, skipVerifyPatch, filteredPatches) {
         } catch (e) {
           try {
             res = statSync(oldFlag);
-          } catch (e) {}
+          } catch (e) {
+            // continue regardless of error
+          }
         }
 
         debug('flag found for %s? %s', vuln.id);

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
   "author": "Remy Sharp",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@commitlint/cli": "^12.1.4",
-    "eslint": "^5.0.0",
-    "eslint-config-prettier": "^5.0.0",
+    "@commitlint/cli": "^17.6.1",
+    "eslint": "^8.38.0",
+    "eslint-config-prettier": "^8.8.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
     "proxyquire": "^2.1.0",
-    "sinon": "^4.0.0",
-    "tap": "^12.0.1",
+    "sinon": "^15.0.4",
+    "tap": "^16.3.4",
     "tap-only": "0.0.5"
   },
   "dependencies": {
@@ -42,5 +42,11 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/snyk/policy.git"
+  },
+  "tap": {
+    "branches": 85,
+    "functions": 95,
+    "lines": 90,
+    "statements": 90
   }
 }

--- a/test/functional/severity-control.test.js
+++ b/test/functional/severity-control.test.js
@@ -6,10 +6,9 @@ const dir = fixtures + '/severity-control';
 const fs = require('fs');
 let vulns = {};
 
-tap.beforeEach(function (done) {
+tap.beforeEach(function () {
   // only contains medium + low - this file is read using fs to ensure refresh
   vulns = JSON.parse(fs.readFileSync(dir + '/vulns.json', 'utf8'));
-  done();
 });
 
 test('severity-control: high (ok=true)', function (t) {


### PR DESCRIPTION
#### What does this PR do?

Bump all dev dependencies to the latest version
- `@commitlint/cli` from 12.1.4 to 17.6.1
- `eslint` from 5.0.0 to 8.38.0
  - needed to add a comment for a squashed exception
- `eslint-config-prettier` from 5.0.0 to 8.8.0
- `sinon` from 4.0.0 to 15.0.4
- `tap` from 12.0.1 to 16.3.4
  - tests are now run synchronously unless a promise is returned
  - added coverage thresholds. Coverage checks are now on by default 

