### PR TITLE
fix: migrate from `promise-fs` to `fs/promises`

### DIFF
--- a/lib/filter/get-vuln-source.js
+++ b/lib/filter/get-vuln-source.js
@@ -5,7 +5,7 @@ module.exports = getVulnSource;
 const debug = require('debug')('snyk:policy');
 const resolve = require('snyk-resolve');
 const path = require('path');
-const statSync = require('fs').statSync;
+const { statSync } = require('fs');
 let { parsePackageString: moduleToObject } = require('snyk-module');
 
 function getVulnSource(vuln, cwd, live) {

--- a/lib/filter/patch.js
+++ b/lib/filter/patch.js
@@ -4,7 +4,7 @@ const cloneDeep = require('lodash.clonedeep');
 const debug = require('debug')('snyk:policy');
 const matchToRule = require('../match').matchToRule;
 const path = require('path');
-const statSync = require('fs').statSync;
+const { statSync } = require('fs');
 const getVulnSource = require('./get-vuln-source');
 
 // cwd is used for testing

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const fs = require('promise-fs');
+const { lstatSync, promises: fs } = require('fs');
 const path = require('path');
 const debug = require('debug')('snyk:policy');
 const match = require('./match');
@@ -95,7 +95,7 @@ function load(root, options) {
   }
   // Check if filename is directory and resolve to correct file path
   try {
-    if (fs.lstatSync(filename).isDirectory()) {
+    if (lstatSync(filename).isDirectory()) {
       filename = path.join(filename, '/.snyk');
     }
   } catch (error) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "email-validator": "^2.0.4",
     "js-yaml": "^3.13.1",
     "lodash.clonedeep": "^4.5.0",
-    "promise-fs": "^2.1.1",
     "semver": "^7.3.4",
     "snyk-module": "^3.0.0",
     "snyk-resolve": "^1.1.0",

--- a/test/unit/get-by-vuln.test.js
+++ b/test/unit/get-by-vuln.test.js
@@ -1,6 +1,6 @@
 const test = require('tap-only');
 const fixtures = __dirname + '/../fixtures';
-const fs = require('promise-fs');
+const { promises: fs } = require('fs');
 const getByVuln = require('../../lib/match').getByVuln;
 const loadFromText = require('../../').loadFromText;
 const policy = require(fixtures + '/ignore/parsed.json');

--- a/test/unit/policy-save.test.js
+++ b/test/unit/policy-save.test.js
@@ -4,13 +4,15 @@ const fixtures = __dirname + '/../fixtures';
 const path = require('path');
 const sinon = require('sinon');
 const writeSpy = sinon.spy();
-const fs = require('promise-fs');
+const { promises: fs } = require('fs');
 const policy = proxyquire('../..', {
-  'promise-fs': {
-    writeFile: function (filename, body) {
-      writeSpy(filename, body);
-      return Promise.resolve();
-    },
+  'fs': {
+    promises:{
+      writeFile: function (filename, body) {
+        writeSpy(filename, body);
+        return Promise.resolve();
+      },
+    }
   },
 });
 

--- a/test/unit/policy.test.js
+++ b/test/unit/policy.test.js
@@ -2,7 +2,7 @@ const test = require('tap-only');
 const policy = require('../..');
 const demunge = require('../../lib/parser').demunge;
 const path = require('path');
-const fs = require('promise-fs');
+const { promises: fs } = require('fs');
 const fixtures = __dirname + '/../fixtures';
 
 test('module loads', function (t) {


### PR DESCRIPTION
#### What does this PR do?

Remove [promise-fs](https://github.com/octet-stream/promise-fs) in favour of [fs/promises](https://nodejs.org/dist/latest-v10.x/docs/api/fs.html#fs_fs_promises_api). `fs/promises` was released in Node v10 (2018) and [promise-fs](https://github.com/octet-stream/promise-fs) has been deprecated for about 4 years. We were using both in the codebase

#### How should this be manually tested?

`npm run test`

and/or

`npm link` then `npm link snyk-policy` in Registry before running tests in Registry