### PR TITLE
chore: update Tap asserts

### DIFF
--- a/test/functional/BST-264.test.js
+++ b/test/functional/BST-264.test.js
@@ -8,6 +8,6 @@ test('broken patch should not be in output', function (t) {
       { loose: true }
     )
     .then(function (policy) {
-      t.deepEqual(policy.patch, {}, 'patch section is empty');
+      t.same(policy.patch, {}, 'patch section is empty');
     });
 });

--- a/test/functional/SC-1026.test.js
+++ b/test/functional/SC-1026.test.js
@@ -9,9 +9,9 @@ test('filtered vulns can still be reviewed', function (t) {
     policy.skipVerifyPatch = true;
     const res = policy.filter(vulns);
     t.equal(res.ok, false, 'still vulnerable');
-    t.isa(res.filtered.ignore, Array);
+    t.type(res.filtered.ignore, Array);
     t.ok(res.filtered.ignore.length > 0, 'some vulns ignored');
-    t.isa(res.filtered.patch, Array);
-    t.notEqual(res.filtered.patch.length, 0, 'some vulns ignored due to patch');
+    t.type(res.filtered.patch, Array);
+    t.not(res.filtered.patch.length, 0, 'some vulns ignored due to patch');
   });
 });

--- a/test/functional/severity-control.test.js
+++ b/test/functional/severity-control.test.js
@@ -15,7 +15,7 @@ test('severity-control: high (ok=true)', function (t) {
   return policy.loadFromText('failThreshold: high').then(function (res) {
     vulns = res.filter(vulns);
     t.equal(vulns.ok, true, 'only failing on high severity');
-    t.notEqual(
+    t.not(
       vulns.vulnerabilities.length,
       0,
       'vulns still available to read'
@@ -27,7 +27,7 @@ test('severity-control: medium (ok=false)', function (t) {
   return policy.loadFromText('failThreshold: medium').then(function (res) {
     vulns = res.filter(vulns);
     t.equal(vulns.ok, false, 'only failing on medium severity');
-    t.notEqual(
+    t.not(
       vulns.vulnerabilities.length,
       0,
       'vulns still available to read'
@@ -39,7 +39,7 @@ test('severity-control: low (ok=false)', function (t) {
   return policy.loadFromText('failThreshold: low').then(function (res) {
     vulns = res.filter(vulns);
     t.equal(vulns.ok, false, 'only failing on low severity');
-    t.notEqual(
+    t.not(
       vulns.vulnerabilities.length,
       0,
       'vulns still available to read'

--- a/test/unit/add-exclude.test.js
+++ b/test/unit/add-exclude.test.js
@@ -17,7 +17,7 @@ test('add a new file pattern to default group', function (t) {
 
       const expected = { global: ['./deps/*.ts'] };
 
-      t.deepEqual(policy.exclude, expected, 'pattern added');
+      t.same(policy.exclude, expected, 'pattern added');
     });
   });
 });
@@ -30,7 +30,7 @@ test('add a new file pattern to global-group', function (t) {
 
       const expected = { global: ['./deps/*.ts'] };
 
-      t.deepEqual(policy.exclude, expected, 'pattern added');
+      t.same(policy.exclude, expected, 'pattern added');
     });
   });
 });
@@ -43,7 +43,7 @@ test('add a new file pattern to code-group', function (t) {
 
       const expected = { code: ['./deps/*.ts'] };
 
-      t.deepEqual(policy.exclude, expected, 'pattern added');
+      t.same(policy.exclude, expected, 'pattern added');
     });
   });
 });
@@ -60,7 +60,7 @@ test('add a new file pattern to iac drift-group', function (t) {
         [validGroup]: ['!aws_iam_*', 'aws_s3_bucket.*'],
       };
 
-      t.deepEqual(policy.exclude, expected, 'pattern added to iac-drift');
+      t.same(policy.exclude, expected, 'pattern added to iac-drift');
     });
   });
 });
@@ -72,7 +72,7 @@ test('add two new unique file pattern to a group', function (t) {
       policy.addExclude('./vendor/*.ts');
       const expected = { global: ['./deps/*.ts', './vendor/*.ts'] };
 
-      t.deepEqual(policy.exclude, expected, 'pattern added');
+      t.same(policy.exclude, expected, 'pattern added');
     });
   });
 });
@@ -87,7 +87,7 @@ test('replace duplicates patterns', function (t) {
 
       const expected = { global: ['./vendor/*.ts', './deps/*.ts'] };
 
-      t.deepEqual(policy.exclude, expected, 'pattern added');
+      t.same(policy.exclude, expected, 'pattern added');
     });
   });
 });
@@ -100,12 +100,12 @@ test('add dates and reasons', function (t) {
         reason: 'incidents already fixed by user',
       });
 
-      t.deepEqual(
+      t.same(
         policy.exclude['global'][0]['./deps/*.ts'].expires,
         '2092-12-24',
         'expires added with the correct format'
       );
-      t.deepEqual(
+      t.same(
         policy.exclude['global'][0]['./deps/*.ts'].reason,
         'incidents already fixed by user',
         'reason added with the correct format'
@@ -127,12 +127,12 @@ test('replace existing objects', function (t) {
         reason: 'it will never happen',
       });
 
-      t.deepEqual(
+      t.same(
         policy.exclude['global'][0]['./deps/*.ts'].expires,
         '2192-12-24',
         'expire replaced'
       );
-      t.deepEqual(
+      t.same(
         policy.exclude['global'][0]['./deps/*.ts'].reason,
         'it will never happen',
         'reason replaced'
@@ -156,18 +156,18 @@ test('only replace duplicates', function (t) {
         reason: 'it will never happen',
       });
 
-      t.deepEqual(
+      t.same(
         policy.exclude['global'][0],
         './vendor/*.go',
         'should keep unique pattern'
       );
 
-      t.deepEqual(
+      t.same(
         policy.exclude['global'][1]['./deps/*.ts'].expires,
         '2192-12-24',
         'expire replaced'
       );
-      t.deepEqual(
+      t.same(
         policy.exclude['global'][1]['./deps/*.ts'].reason,
         'it will never happen',
         'reason replaced'

--- a/test/unit/add.test.js
+++ b/test/unit/add.test.js
@@ -41,9 +41,9 @@ test('add errors without options', function (t) {
       expires: d2,
     });
 
-    t.deepEqual(Object.keys(policy.patch), ['a'], '`a` is the only root');
-    t.deepEqual(policy.patch.a.length, 2, 'two paths on `a`');
-    t.deepEqual(policy.patch.a[1]['a > b > c'].expires, d2, 'metadata saved');
+    t.same(Object.keys(policy.patch), ['a'], '`a` is the only root');
+    t.same(policy.patch.a.length, 2, 'two paths on `a`');
+    t.same(policy.patch.a[1]['a > b > c'].expires, d2, 'metadata saved');
   });
 });
 
@@ -58,7 +58,7 @@ test('add ignore with valid reasonType', function (t) {
     })
     .then(function (policy) {
       t.ok('error not thrown');
-      t.deepEqual(
+      t.same(
         policy.ignore.a[0]['a > b'].reasonType,
         'wont-fix',
         'metadata saved'
@@ -101,7 +101,7 @@ test('add ignore with valid ignoredBy', function (t) {
     })
     .then(function (policy) {
       t.ok('error not thrown');
-      t.deepEqual(
+      t.same(
         policy.ignore.a[0]['a > b'].ignoredBy,
         ignoredBy,
         'metadata saved'

--- a/test/unit/filter-ignore.test.js
+++ b/test/unit/filter-ignore.test.js
@@ -71,7 +71,7 @@ test('ignored vulns do not turn up in tests', function (t) {
       }, {});
       t.same(actual, expected, 'filtered vulns include ignore rules');
 
-      t.notEqual(
+      t.not(
         vulns.vulnerabilities.every(function (vuln) {
           return !!vuln.ignored;
         }),

--- a/test/unit/filter-patch.test.js
+++ b/test/unit/filter-patch.test.js
@@ -66,7 +66,7 @@ test('patched vulns do not turn up in tests', function (t) {
       }, {});
       t.same(actual, expected, 'filtered vulns include patch rules');
 
-      t.notEqual(
+      t.not(
         vulns.vulnerabilities.every(function (vuln) {
           return !!vuln.patches;
         }),

--- a/test/unit/filter.test.js
+++ b/test/unit/filter.test.js
@@ -11,6 +11,6 @@ test('ignored vulns do not turn up in tests', function (t) {
     // should strip all
     vulns = config.filter(vulns);
     t.equal(vulns.ok, true, 'post filter, we have no vulns');
-    t.deepEqual(vulns.vulnerabilities, [], 'vulns stripped');
+    t.same(vulns.vulnerabilities, [], 'vulns stripped');
   });
 });

--- a/test/unit/get-by-vuln.test.js
+++ b/test/unit/get-by-vuln.test.js
@@ -21,8 +21,8 @@ test('getByVuln (no vulns)', function (t) {
 test('getByVuln', function (t) {
   const res = vulns.vulnerabilities.map(getByVuln.bind(null, policy));
   res.forEach(function (res, i) {
-    t.equals(res.type, 'ignore', 'expect ignore for ' + res.id);
-    t.equals(res.id, vulns.vulnerabilities[i].id, 'matched id: ' + res.id);
+    t.equal(res.type, 'ignore', 'expect ignore for ' + res.id);
+    t.equal(res.id, vulns.vulnerabilities[i].id, 'matched id: ' + res.id);
   });
   t.end();
 });

--- a/test/unit/ignore-policy.test.js
+++ b/test/unit/ignore-policy.test.js
@@ -8,7 +8,7 @@ test('single load', function (t) {
     .then(function (res) {
       t.equal(Object.keys(res.ignore).length, 0, 'ignore policy is empty');
       t.equal(Object.keys(res.patch).length, 0, 'patch policy is empty');
-      t.isa(res.filter, 'function', 'helper methods attached');
+      t.type(res.filter, 'function', 'helper methods attached');
     });
 });
 
@@ -17,7 +17,7 @@ test('multiple load', function (t) {
     .load([fixtures + '/patch', fixtures + '/patch-mean'])
     .then(function (res) {
       t.equal(Object.keys(res.ignore).length, 0, 'ignore policy is empty');
-      t.notEqual(Object.keys(res.patch).length, 0, 'patch policy is not empty');
-      t.isa(res.filter, 'function', 'helper methods attached');
+      t.not(Object.keys(res.patch).length, 0, 'patch policy is not empty');
+      t.type(res.filter, 'function', 'helper methods attached');
     });
 });

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -11,7 +11,7 @@ test('parser fills out defaults', function (t) {
     patch: {},
   };
 
-  t.deepEqual(res, expect, 'parser fills defaults');
+  t.same(res, expect, 'parser fills defaults');
   t.end();
 });
 
@@ -23,7 +23,7 @@ test('parser fills out defaults for invalid inputs', function (t) {
     patch: {},
   };
 
-  t.deepEqual(res, expect, 'parser fills defaults for invalid inputs');
+  t.same(res, expect, 'parser fills defaults for invalid inputs');
   t.end();
 });
 
@@ -42,7 +42,7 @@ test('parser does not modify default parsed format', function (t) {
 
   const res = parser.import(yaml.safeDump(expect));
 
-  t.deepEqual(res, expect, 'parser does nothing extra (v1 vs v1)');
+  t.same(res, expect, 'parser does nothing extra (v1 vs v1)');
   t.end();
 });
 
@@ -73,21 +73,21 @@ test('demunge', function (t) {
   t.equal(res.patch.length, 2, 'two patched items');
   t.equal(res.ignore.length, 3, 'three ignored items');
   t.equal(res.exclude.length, 2, 'two excluded categories');
-  t.deepEqual(
+  t.same(
     res.patch.map(function (o) {
       return o.id;
     }),
     patchIds,
     'patch ids found in the right place'
   );
-  t.deepEqual(
+  t.same(
     res.ignore.map(function (o) {
       return o.id;
     }),
     ignoreIds,
     'ignore ids found in the right place'
   );
-  t.deepEqual(
+  t.same(
     res.exclude.map(function (o) {
       return o.id;
     }),

--- a/test/unit/policy-args.test.js
+++ b/test/unit/policy-args.test.js
@@ -16,7 +16,7 @@ test('policy.load (no args)', function (t) {
       __created: res.__created ? new Date(res.__created) : false,
     };
 
-    t.deepEqual(stripFunctions(res), expect, 'policy is as expected');
+    t.same(stripFunctions(res), expect, 'policy is as expected');
   });
 });
 
@@ -31,14 +31,14 @@ test('policy.load (options first)', function (t) {
       __created: res.__created ? new Date(res.__created) : false,
     };
 
-    t.deepEqual(stripFunctions(res), expect, 'policy is as expected');
+    t.same(stripFunctions(res), expect, 'policy is as expected');
   });
 });
 
 test('policy loads without args - non simple', function (t) {
   process.chdir(fixtures + '/ignore');
   return policy.load().then(function (policy) {
-    t.notEqual(Object.keys(policy.ignore), 0, 'has ignore rules');
+    t.not(Object.keys(policy.ignore), 0, 'has ignore rules');
   });
 });
 

--- a/test/unit/policy-parse.test.js
+++ b/test/unit/policy-parse.test.js
@@ -16,7 +16,7 @@ test('missing dash on policy is fixed up', function (t) {
 
     t.equal(paths1.length, 3, 'has 3 paths');
     t.equal(paths1.length, paths2.length, 'has equal length');
-    t.deepEqual(paths1, paths2, 'missing dash was hotfixed');
+    t.same(paths1, paths2, 'missing dash was hotfixed');
   });
 });
 

--- a/test/unit/policy.test.js
+++ b/test/unit/policy.test.js
@@ -6,7 +6,7 @@ const fs = require('promise-fs');
 const fixtures = __dirname + '/../fixtures';
 
 test('module loads', function (t) {
-  t.isa(policy, 'object', 'policy has loaded an object');
+  t.type(policy, 'object', 'policy has loaded an object');
   t.end();
 });
 
@@ -23,7 +23,7 @@ test('policy.load (single)', function (t) {
 
     stripFunctions(res);
 
-    t.deepEqual(res, expect, 'policy is as expected');
+    t.same(res, expect, 'policy is as expected');
   });
 });
 
@@ -43,7 +43,7 @@ test('policy.load (single .snyk in path name)', function (t) {
 
     stripFunctions(res);
 
-    t.deepEqual(res, expect, 'policy is as expected');
+    t.same(res, expect, 'policy is as expected');
   });
 });
 
@@ -65,7 +65,7 @@ test('policy.load (double .snyk in path name)', function (t) {
 
       stripFunctions(res);
 
-      t.deepEqual(res, expect, 'policy is as expected');
+      t.same(res, expect, 'policy is as expected');
     });
 });
 
@@ -85,7 +85,7 @@ test('policy.load (single .snyk in path name but at upper level)', function (t) 
 
     stripFunctions(res);
 
-    t.deepEqual(res, expect, 'policy is as expected');
+    t.same(res, expect, 'policy is as expected');
   });
 });
 
@@ -123,9 +123,9 @@ test('policy.load (multiple - ignore last)', function (t) {
         'npm:method-override:20170927',
         'npm:marked:20170907',
       ];
-      t.deepEqual(res.ignore, {}, 'nothing is ignored');
+      t.same(res.ignore, {}, 'nothing is ignored');
       t.ok(res.suggest, 'suggestions are present');
-      t.deepEqual(
+      t.same(
         Object.keys(res.suggest),
         ids,
         'suggestions are present and correct'
@@ -147,8 +147,8 @@ test('policy.load (multiple - ignore last - trust deep policy)', function (t) {
         'npm:marked:20170907',
       ];
       t.notOk(res.suggest, 'no suggestions');
-      t.notEqual(Object.keys(res.ignore).length, 0, 'has more than one ignore');
-      t.deepEqual(
+      t.not(Object.keys(res.ignore).length, 0, 'has more than one ignore');
+      t.same(
         Object.keys(res.ignore),
         ids,
         'inherited ignores are correct'
@@ -187,8 +187,8 @@ test('policy.loadFromText', function (t) {
     .then(policy.loadFromText)
     .then(function (fromText) {
       return policy.load(fixtures + '/ignore').then(function (fromDir) {
-        t.deepEqual(fromText.patch, fromDir.patch);
-        t.deepEqual(fromText.ignore, fromDir.ignore);
+        t.same(fromText.patch, fromDir.patch);
+        t.same(fromText.ignore, fromDir.ignore);
         t.equal(fromText.version, fromDir.version);
       });
     });
@@ -203,7 +203,7 @@ test('policy.load (multiple - ENOENT - loose)', function (t) {
         'npm:uglify-js:20151024',
         'npm:semver:20150403',
       ];
-      t.deepEqual(Object.keys(res.patch), ids, 'policy loaded');
+      t.same(Object.keys(res.patch), ids, 'policy loaded');
     });
 });
 


### PR DESCRIPTION
#### What does this PR do?

Replace deprecated Tap asserts:
- `t.deepEqual` to `t.same`
- `t.isa` to `t.type`
- `t.notEqual` to `t.not`
- `t.equals` to `t.equal`

#### How should this be manually tested?

`npm run test`
