### PR TITLE
chore: remove proxyquire

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "eslint-config-prettier": "^8.8.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
-    "proxyquire": "^2.1.0",
     "sinon": "^15.0.4",
     "tap": "^16.3.4",
     "tap-only": "0.0.5"

--- a/test/unit/filter-patch.test.js
+++ b/test/unit/filter-patch.test.js
@@ -1,29 +1,23 @@
-const test = require('tap').test;
+const fs = require('fs');
+const sinon = require('sinon');
+const resolve = require('snyk-resolve');
+const { test, afterEach } = require('tap');
+const policy = require('../../');
+const patch = require('../../lib/filter/patch')
+
 const fixtures = __dirname + '/../fixtures/patch';
 const vulns = require(fixtures + '/vulns.json');
-const proxyquire = require('proxyquire');
-const policy = require('../../');
-const patch = proxyquire('../../lib/filter/patch', {
-  './get-vuln-source': proxyquire('../../lib/filter/get-vuln-source', {
-    'snyk-resolve': {
-      sync: function () {
-        return '.';
-      },
-    },
-    fs: {
-      statSync: function () {
-        throw new Error('nope');
-      },
-    },
-  }),
-  fs: {
-    statSync: function () {
-      return true;
-    },
-  },
+
+var sandbox = sinon.createSandbox();
+
+afterEach(function () {
+  sandbox.restore();
 });
 
 test('patched vulns do not turn up in tests', function (t) {
+  sandbox.stub(fs, 'statSync').returns(true);
+  sandbox.stub(resolve, 'sync').returns('.');
+
   policy
     .load(fixtures)
     .then(function (config) {


### PR DESCRIPTION
#### What does this PR do?

Removes `proxyquire` in favour of `sinon.stub` for stubbing functionality during testing. We're already using `sinon` and `proxyquire` does not play nice with ESM

#### How should this be manually tested?

`npm run test`
