### PR TITLE
fix: adds the package.json to the dist folder of the published library

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "Snyk's policy parser and matching logic",
   "files": [
+    "dist/package.json",
     "dist/lib",
     "LICENSE",
     "README.md"


### PR DESCRIPTION
#### What does this PR do?

Adds the package.json to the `dist` folder of the published library.

The library exports it's version and so needs to be able to inspect it's own package.json file. The new TypeScript compilation did not include it in the dist directory as expected

#### How should this be manually tested?

Run `npm pack` to verify that the `package.json` is included in the `dist` directory. If you know how one could leverage `npm link` to test the packaged library with Registry, let me know!
