### PR TITLE
fix: default policy file version to `v1`

### DIFF
--- a/lib/parser/index.ts
+++ b/lib/parser/index.ts
@@ -22,7 +22,7 @@ function imports(rawYaml = '') {
   }
 
   if (!data.version) {
-    data.version = version();
+    data.version = 'v1';
   }
 
   if (data.version === 'v1') {


### PR DESCRIPTION
#### What does this PR do?

Previously, the policy file version defaulted to the current version of the library.

#### How should this be manually tested?

Manually bump the `version` in `package.json` to `3.0.0` and run `npm pack`
Run `npm install <policyRepoPath>/snyk-policy-3.0.0.tgz` in Registry before running `npm run test`
