### PR TITLE
chore: switch to vitest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
           at: ~/policy
       - run:
           name: Run tests
-          command: npm run test -- --ci
+          command: npm run test
       - store_test_results:
           path: reports/jest/
       - store_artifacts:

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "format": "prettier --write '{lib,test}/**/*.?s'",
     "prepack": "npm run build",
     "check-tests": "! grep 'test.only' test/**/*.test.ts -n",
-    "tap": "tap test/**/*.test.ts -R spec --timeout=60 --ts",
-    "test": "npm run check-tests && npm run tap"
+    "test": "npm run check-tests && vitest run --coverage"
   },
   "keywords": [
     "snyk"
@@ -32,15 +31,14 @@
     "@commitlint/cli": "^17.6.1",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^5.59.1",
+    "@vitest/coverage-c8": "^0.30.1",
     "eslint": "^8.39.0",
     "eslint-config-prettier": "^8.8.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
-    "sinon": "^15.0.4",
-    "tap": "^16.3.4",
-    "tap-only": "0.0.5",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.4"
+    "typescript": "^5.0.4",
+    "vitest": "^0.30.1"
   },
   "dependencies": {
     "debug": "^4.1.1",
@@ -55,11 +53,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/snyk/policy.git"
-  },
-  "tap": {
-    "branches": 85,
-    "functions": 90,
-    "lines": 90,
-    "statements": 90
   }
 }

--- a/test/functional/BST-264.test.ts
+++ b/test/functional/BST-264.test.ts
@@ -1,13 +1,11 @@
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import * as policy from '../../lib';
 
-test('broken patch should not be in output', function (t) {
-  return policy
-    .load(
-      __dirname + '/../fixtures/issues/BST-264/missing-path-to-package.snyk',
-      { loose: true }
-    )
-    .then(function (policy) {
-      t.same(policy.patch, {}, 'patch section is empty');
-    });
+test('broken patch should not be in output', async () => {
+  const res = await policy.load(
+    __dirname + '/../fixtures/issues/BST-264/missing-path-to-package.snyk',
+    { loose: true }
+  );
+
+  expect(res.patch).toStrictEqual({});
 });

--- a/test/functional/SC-1026.test.ts
+++ b/test/functional/SC-1026.test.ts
@@ -1,18 +1,19 @@
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import * as policy from '../../lib';
 
 const fixtures = __dirname + '/../fixtures';
 const dir = fixtures + '/filter-and-track';
 const vulns = require(dir + '/vulns.json');
 
-test('filtered vulns can still be reviewed', function (t) {
-  return policy.load(dir, { loose: true }).then(function (policy) {
-    policy.skipVerifyPatch = true;
-    const res = policy.filter(vulns);
-    t.equal(res.ok, false, 'still vulnerable');
-    t.type(res.filtered.ignore, Array);
-    t.ok(res.filtered.ignore.length > 0, 'some vulns ignored');
-    t.type(res.filtered.patch, Array);
-    t.not(res.filtered.patch.length, 0, 'some vulns ignored due to patch');
-  });
+test('filtered vulns can still be reviewed', async () => {
+  const p = await policy.load(dir, { loose: true });
+
+  p.skipVerifyPatch = true;
+  const res = p.filter(vulns);
+
+  expect(res.ok).toBe(false);
+  expect(res.filtered.ignore).toBeInstanceOf(Array);
+  expect(res.filtered.ignore).length.greaterThan(0);
+  expect(res.filtered.patch).toBeInstanceOf(Array);
+  expect(res.filtered.patch).not.toHaveLength(0);
 });

--- a/test/functional/SC-1084.test.ts
+++ b/test/functional/SC-1084.test.ts
@@ -1,16 +1,12 @@
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import * as policy from '../../lib';
 
 const fixtures = __dirname + '/../fixtures';
 const dir1 = fixtures + '/ignore';
 const dir2 = fixtures + '/ignore-duped';
 
-test('multiple policies merge when the vuln id is the same in ignore', function (t) {
-  return policy.load(['.', dir1, dir2], { loose: true }).then(function (res) {
-    t.equal(
-      res.suggest['npm:hawk:20160119'].length,
-      2,
-      'hawk is ignored in two places'
-    );
-  });
+test('multiple policies merge when the vuln id is the same in ignore', async () => {
+  const res = await policy.load(['.', dir1, dir2], { loose: true });
+
+  expect(res.suggest['npm:hawk:20160119']).toHaveLength(2);
 });

--- a/test/functional/append.test.ts
+++ b/test/functional/append.test.ts
@@ -1,24 +1,19 @@
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import * as policy from '../../lib';
 import { needsFixing } from '../../lib/parser/v1';
 
 const fixtures = __dirname + '/../fixtures/issues/SC-1106/';
 const withDash = fixtures + '/pre-update.snyk';
 
-test('merging new policy data does not corrupt', function (t) {
-  return policy.load(withDash).then(function (policy) {
-    policy.addIgnore({
-      id: 'npm:hawk:20160119',
-      path: 'octonode > request > hawk',
-      expires: new Date('2016-05-24T13:46:19.066Z'),
-      reason: 'none given',
-    });
-
-    t.equal(needsFixing(policy.ignore), false, 'no corruption');
-    t.equal(
-      Object.keys(policy.ignore['npm:hawk:20160119']).length,
-      3,
-      'has 3 rules'
-    );
+test('merging new policy data does not corrupt', async () => {
+  const res = await policy.load(withDash);
+  res.addIgnore({
+    id: 'npm:hawk:20160119',
+    path: 'octonode > request > hawk',
+    expires: new Date('2016-05-24T13:46:19.066Z'),
+    reason: 'none given',
   });
+
+  expect(needsFixing(res.ignore)).toBe(false);
+  expect(Object.keys(res.ignore['npm:hawk:20160119'])).toHaveLength(3);
 });

--- a/test/functional/load-multi.test.ts
+++ b/test/functional/load-multi.test.ts
@@ -1,13 +1,13 @@
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import * as policy from '../../lib';
 
 const fixtures = __dirname + '/../fixtures';
 const dir1 = fixtures + '/empty';
 const dir2 = fixtures + '/patch';
 
-test('multiple directories, one with policy, one without', function (t) {
-  return policy.load([dir1, dir2], { loose: true }).then(function (res) {
-    t.ok(res.patch, 'patch property is present');
-    t.equal(Object.keys(res.patch).length, 3, 'patches found');
-  });
+test('multiple directories, one with policy, one without', async () => {
+  const res = await policy.load([dir1, dir2], { loose: true });
+
+  expect(res.patch).toBeTruthy();
+  expect(Object.keys(res.patch)).toHaveLength(3);
 });

--- a/test/functional/load-policies.test.ts
+++ b/test/functional/load-policies.test.ts
@@ -1,9 +1,9 @@
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import * as policy from '../../lib';
 
 const fixtures = __dirname + '/../fixtures';
 
-test('load different types of policies', function (t) {
+test('load different types of policies', () => {
   const dirs = [
     'patch',
     'deep-policy',
@@ -21,12 +21,9 @@ test('load different types of policies', function (t) {
   ];
 
   return Promise.all(
-    dirs.map(function (dir) {
-      return policy
-        .load(fixtures + '/' + dir, { loose: true })
-        .then(function (res) {
-          t.ok('load succeeded for ' + dir);
-        });
+    dirs.map((dir) => {
+      expect(() => policy.load(fixtures + '/' + dir, { loose: true })).not
+        .toThrow;
     })
   );
 });

--- a/test/unit/add-exclude.test.ts
+++ b/test/unit/add-exclude.test.ts
@@ -1,177 +1,155 @@
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import { create } from '../../lib';
 
-test('use of invalid file pattern-group throws errors', function (t) {
-  return create().then(function (policy) {
-    t.throws(function () {
-      const invalidGroup = 'unmanaged';
-      policy.addExclude('./deps/*.ts', invalidGroup);
-    }, 'invalid file pattern-group');
-  });
+test('use of invalid file pattern-group throws errors', async () => {
+  let policy = await create();
+
+  expect(() => {
+    const invalidGroup = 'unmanaged';
+    policy.addExclude('./deps/*.ts', invalidGroup);
+  }).toThrow('invalid file pattern-group');
 });
 
-test('add a new file pattern to default group', function (t) {
-  return create().then(function (policy) {
-    t.doesNotThrow(function () {
-      policy.addExclude('./deps/*.ts');
+test('add a new file pattern to default group', async (t) => {
+  let policy = await create();
 
-      const expected = { global: ['./deps/*.ts'] };
+  expect(() => {
+    policy.addExclude('./deps/*.ts');
 
-      t.same(policy.exclude, expected, 'pattern added');
-    });
-  });
+    const expected = { global: ['./deps/*.ts'] };
+    expect(policy.exclude).toStrictEqual(expected);
+  }).does.not.toThrow();
 });
 
-test('add a new file pattern to global-group', function (t) {
-  return create().then(function (policy) {
-    t.doesNotThrow(function () {
-      const validGroup = 'global';
-      policy.addExclude('./deps/*.ts', validGroup);
+test('add a new file pattern to global-group', async (t) => {
+  let policy = await create();
 
-      const expected = { global: ['./deps/*.ts'] };
+  expect(() => {
+    const validGroup = 'global';
+    policy.addExclude('./deps/*.ts', validGroup);
 
-      t.same(policy.exclude, expected, 'pattern added');
-    });
-  });
+    const expected = { global: ['./deps/*.ts'] };
+    expect(policy.exclude).toStrictEqual(expected);
+  }).does.not.toThrow();
 });
 
-test('add a new file pattern to code-group', function (t) {
-  return create().then(function (policy) {
-    t.doesNotThrow(function () {
-      const validGroup = 'code';
-      policy.addExclude('./deps/*.ts', validGroup);
+test('add a new file pattern to code-group', async (t) => {
+  let policy = await create();
+  expect(() => {
+    const validGroup = 'code';
+    policy.addExclude('./deps/*.ts', validGroup);
 
-      const expected = { code: ['./deps/*.ts'] };
-
-      t.same(policy.exclude, expected, 'pattern added');
-    });
-  });
+    const expected = { code: ['./deps/*.ts'] };
+    expect(policy.exclude).toStrictEqual(expected);
+  }).does.not.toThrow();
 });
 
-test('add a new file pattern to iac drift-group', function (t) {
-  return create().then(function (policy) {
-    t.doesNotThrow(function () {
-      const validGroup = 'iac-drift';
+test('add a new file pattern to iac drift-group', async (t) => {
+  let policy = await create();
+  expect(() => {
+    const validGroup = 'iac-drift';
 
-      policy.addExclude('!aws_iam_*', validGroup);
-      policy.addExclude('aws_s3_bucket.*', validGroup);
+    policy.addExclude('!aws_iam_*', validGroup);
+    policy.addExclude('aws_s3_bucket.*', validGroup);
 
-      const expected = {
-        [validGroup]: ['!aws_iam_*', 'aws_s3_bucket.*'],
-      };
+    const expected = {
+      [validGroup]: ['!aws_iam_*', 'aws_s3_bucket.*'],
+    };
 
-      t.same(policy.exclude, expected, 'pattern added to iac-drift');
-    });
-  });
+    expect(policy.exclude).toStrictEqual(expected);
+  }).does.not.toThrow();
 });
 
-test('add two new unique file pattern to a group', function (t) {
-  return create().then(function (policy) {
-    t.doesNotThrow(function () {
-      policy.addExclude('./deps/*.ts');
-      policy.addExclude('./vendor/*.ts');
-      const expected = { global: ['./deps/*.ts', './vendor/*.ts'] };
+test('add two new unique file pattern to a group', async (t) => {
+  let policy = await create();
+  expect(() => {
+    policy.addExclude('./deps/*.ts');
+    policy.addExclude('./vendor/*.ts');
+    const expected = { global: ['./deps/*.ts', './vendor/*.ts'] };
 
-      t.same(policy.exclude, expected, 'pattern added');
-    });
-  });
+    expect(policy.exclude).toStrictEqual(expected);
+  }).does.not.toThrow();
 });
 
-test('replace duplicates patterns', function (t) {
-  return create().then(function (policy) {
-    t.doesNotThrow(function () {
-      policy.addExclude('./deps/*.ts');
-      policy.addExclude('./deps/*.ts');
-      policy.addExclude('./vendor/*.ts');
-      policy.addExclude('./deps/*.ts');
+test('replace duplicates patterns', async (t) => {
+  let policy = await create();
 
-      const expected = { global: ['./vendor/*.ts', './deps/*.ts'] };
+  expect(() => {
+    policy.addExclude('./deps/*.ts');
+    policy.addExclude('./deps/*.ts');
+    policy.addExclude('./vendor/*.ts');
+    policy.addExclude('./deps/*.ts');
 
-      t.same(policy.exclude, expected, 'pattern added');
-    });
-  });
+    const expected = { global: ['./vendor/*.ts', './deps/*.ts'] };
+
+    expect(policy.exclude).toStrictEqual(expected);
+  }).does.not.toThrow();
 });
 
-test('add dates and reasons', function (t) {
-  return create().then(function (policy) {
-    t.doesNotThrow(function () {
-      policy.addExclude('./deps/*.ts', 'global', {
-        expires: '2092-12-24',
-        reason: 'incidents already fixed by user',
-      });
-
-      t.same(
-        policy.exclude['global'][0]['./deps/*.ts'].expires,
-        '2092-12-24',
-        'expires added with the correct format'
-      );
-      t.same(
-        policy.exclude['global'][0]['./deps/*.ts'].reason,
-        'incidents already fixed by user',
-        'reason added with the correct format'
-      );
+test('add dates and reasons', async (t) => {
+  let policy = await create();
+  expect(() => {
+    policy.addExclude('./deps/*.ts', 'global', {
+      expires: '2092-12-24',
+      reason: 'incidents already fixed by user',
     });
-  });
+
+    expect(policy.exclude['global'][0]['./deps/*.ts'].expires).toBe(
+      '2092-12-24'
+    );
+
+    expect(policy.exclude['global'][0]['./deps/*.ts'].reason).toBe(
+      'incidents already fixed by user'
+    );
+  }).does.not.toThrow();
 });
 
-test('replace existing objects', function (t) {
-  return create().then(function (policy) {
-    t.doesNotThrow(function () {
-      policy.addExclude('./deps/*.ts', 'global', {
-        expires: '2092-12-24',
-        reason: 'incidents already fixed by user',
-      });
-
-      policy.addExclude('./deps/*.ts', 'global', {
-        expires: '2192-12-24',
-        reason: 'it will never happen',
-      });
-
-      t.same(
-        policy.exclude['global'][0]['./deps/*.ts'].expires,
-        '2192-12-24',
-        'expire replaced'
-      );
-      t.same(
-        policy.exclude['global'][0]['./deps/*.ts'].reason,
-        'it will never happen',
-        'reason replaced'
-      );
+test('replace existing objects', async (t) => {
+  let policy = await create();
+  expect(() => {
+    policy.addExclude('./deps/*.ts', 'global', {
+      expires: '2092-12-24',
+      reason: 'incidents already fixed by user',
     });
-  });
+
+    policy.addExclude('./deps/*.ts', 'global', {
+      expires: '2192-12-24',
+      reason: 'it will never happen',
+    });
+
+    expect(policy.exclude['global'][0]['./deps/*.ts'].expires).toBe(
+      '2192-12-24'
+    );
+
+    expect(policy.exclude['global'][0]['./deps/*.ts'].reason).toBe(
+      'it will never happen'
+    );
+  }).does.not.toThrow();
 });
 
-test('only replace duplicates', function (t) {
-  return create().then(function (policy) {
-    t.doesNotThrow(function () {
-      policy.addExclude('./deps/*.ts', 'global', {
-        expires: '2092-12-24',
-        reason: 'incidents already fixed by user',
-      });
-
-      policy.addExclude('./vendor/*.go', 'global');
-
-      policy.addExclude('./deps/*.ts', 'global', {
-        expires: '2192-12-24',
-        reason: 'it will never happen',
-      });
-
-      t.same(
-        policy.exclude['global'][0],
-        './vendor/*.go',
-        'should keep unique pattern'
-      );
-
-      t.same(
-        policy.exclude['global'][1]['./deps/*.ts'].expires,
-        '2192-12-24',
-        'expire replaced'
-      );
-      t.same(
-        policy.exclude['global'][1]['./deps/*.ts'].reason,
-        'it will never happen',
-        'reason replaced'
-      );
+test('only replace duplicates', async (t) => {
+  let policy = await create();
+  expect(() => {
+    policy.addExclude('./deps/*.ts', 'global', {
+      expires: '2092-12-24',
+      reason: 'incidents already fixed by user',
     });
-  });
+
+    policy.addExclude('./vendor/*.go', 'global');
+
+    policy.addExclude('./deps/*.ts', 'global', {
+      expires: '2192-12-24',
+      reason: 'it will never happen',
+    });
+
+    expect(policy.exclude['global'][0]).toBe('./vendor/*.go');
+
+    expect(policy.exclude['global'][1]['./deps/*.ts'].expires).toBe(
+      '2192-12-24'
+    );
+
+    expect(policy.exclude['global'][1]['./deps/*.ts'].reason).toBe(
+      'it will never happen'
+    );
+  }).does.not.toThrow();
 });

--- a/test/unit/add.test.ts
+++ b/test/unit/add.test.ts
@@ -1,32 +1,20 @@
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import { create } from '../../lib';
 
-test('add errors without options', function (t) {
-  return create().then(function (policy) {
-    t.throws(
-      function () {
-        policy.addPatch();
-      },
-      /^policy.add: required option/,
-      'errors without opts'
-    );
-  });
+test('add errors without options', async () => {
+  let policy = await create();
+  expect(policy.addPatch).toThrow(/^policy.add: required option/);
 });
 
-test('add errors without type', function (t) {
-  return create().then(function (policy) {
-    t.throws(
-      function () {
-        policy.add();
-      },
-      /^policy.add: unknown type/,
-      'errors without type'
-    );
-  });
+test('add errors without type', async () => {
+  let policy = await create();
+  expect(policy.add).toThrow(/^policy.add: unknown type/);
 });
 
-test('add errors without options', function (t) {
-  return create().then(function (policy) {
+test('add errors without options 2', async () => {
+  let policy = await create();
+
+  expect(() => {
     const d1 = new Date();
     const d2 = new Date('2016-05-24T13:46:19.066Z');
     policy.addPatch({
@@ -41,98 +29,73 @@ test('add errors without options', function (t) {
       expires: d2,
     });
 
-    t.same(Object.keys(policy.patch), ['a'], '`a` is the only root');
-    t.same(policy.patch.a.length, 2, 'two paths on `a`');
-    t.same(policy.patch.a[1]['a > b > c'].expires, d2, 'metadata saved');
+    expect(Object.keys(policy.patch)).toBe(['a']);
+    expect(policy.patch.a).toHaveLength(2);
+    expect(policy.patch.a[1]['a > b > c'].expires).toBe(d2);
   });
 });
 
-test('add ignore with valid reasonType', function (t) {
-  return create()
-    .then(function (policy) {
-      return policy.addIgnore({
-        id: 'a',
-        path: 'a > b',
-        reasonType: 'wont-fix',
-      });
-    })
-    .then(function (policy) {
-      t.ok('error not thrown');
-      t.same(
-        policy.ignore.a[0]['a > b'].reasonType,
-        'wont-fix',
-        'metadata saved'
-      );
-    })
-    .catch(function () {
-      t.fail('error thrown thrown');
+test('add ignore with valid reasonType', async () => {
+  let policy = await create();
+
+  expect(() => {
+    policy.addIgnore({
+      id: 'a',
+      path: 'a > b',
+      reasonType: 'wont-fix',
     });
+
+    expect(policy.ignore.a[0]['a > b'].reasonType).toBe('wont-fix');
+  }).does.not.throw();
 });
 
-test('add ignore with invalid reasonType', function (t) {
-  return create()
-    .then(function (policy) {
-      return policy.addIgnore({
+test('add ignore with invalid reasonType', async () => {
+  let policy = await create();
+
+  expect(() =>
+    policy
+      .addIgnore({
         id: 'a',
         path: 'a > b',
         reasonType: 'test',
-      });
-    })
-    .then(function () {
-      t.fail('error not thrown');
-    })
-    .catch(function (err) {
-      t.equal(err.message, 'invalid reasonType test', 'error is thrown');
-    });
+      })
+      .catch((err) => {
+        expect(err.message).toBe('invalid reasonType test');
+        throw err;
+      })
+  ).toThrow();
 });
 
-test('add ignore with valid ignoredBy', function (t) {
+test('add ignore with valid ignoredBy', async () => {
   const ignoredBy = {
     name: 'Joe Bloggs',
     email: 'joe@acme.org',
   };
-  return create()
-    .then(function (policy) {
-      return policy.addIgnore({
-        id: 'a',
-        path: 'a > b',
-        ignoredBy: ignoredBy,
-      });
-    })
-    .then(function (policy) {
-      t.ok('error not thrown');
-      t.same(
-        policy.ignore.a[0]['a > b'].ignoredBy,
-        ignoredBy,
-        'metadata saved'
-      );
-    })
-    .catch(function () {
-      t.fail('error thrown thrown');
-    });
+
+  let policy = await create();
+
+  await policy.addIgnore({
+    id: 'a',
+    path: 'a > b',
+    ignoredBy: ignoredBy,
+  });
+
+  expect(policy.ignore.a[0]['a > b'].ignoredBy).toBe(ignoredBy);
 });
 
-test('add ignore with invalid ignoredBy', function (t) {
+test('add ignore with invalid ignoredBy', async () => {
   const ignoredBy = {
     name: 'Joe Bloggs',
     email: 'joeacme.org',
   };
-  return create()
-    .then(function (policy) {
-      return policy.addIgnore({
-        id: 'a',
-        path: 'a > b',
-        ignoredBy: ignoredBy,
-      });
+
+  let policy = await create();
+
+  expect(() =>
+    policy.addIgnore({
+      id: 'a',
+      path: 'a > b',
+      ignoredBy: ignoredBy,
     })
-    .then(function () {
-      t.fail('error not thrown');
-    })
-    .catch(function (err) {
-      t.equal(
-        err.message,
-        'ignoredBy.email must be a valid email address',
-        'error is thrown'
-      );
-    });
+  ).toThrow('ignoredBy.email must be a valid email address');
 });

--- a/test/unit/filter-expired.test.ts
+++ b/test/unit/filter-expired.test.ts
@@ -1,30 +1,29 @@
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import * as policy from '../../lib';
 
 const fixtures = __dirname + '/../fixtures/ignore-expired';
 const fixturesNoQuotes = __dirname + '/../fixtures/ignore-expired-no-quotes';
 let vulns = require(fixtures + '/vulns.json');
 
-test('expired policies do not strip', function (t) {
-  return policy.load(fixtures).then(function (config) {
-    const start = vulns.vulnerabilities.length;
-    t.ok(start > 0, 'we have vulns to start with');
+test('expired policies do not strip', async () => {
+  const config = await policy.load(fixtures);
+  const start = vulns.vulnerabilities.length;
+  expect(start).toBeGreaterThan(0);
 
-    // should keep all vulns, because all of the ignores expired
-    vulns = config.filter(vulns);
-    t.equal(vulns.ok, false, 'post filter, we still have vulns');
-    t.equal(vulns.vulnerabilities.length, start, 'all vulns remained');
-  });
+  // should keep all vulns, because all of the ignores expired
+  vulns = config.filter(vulns);
+  expect(vulns.ok).toBe(false);
+  expect(vulns.vulnerabilities).toHaveLength(start);
 });
 
-test('expired policies do not strip (no quotes)', function (t) {
-  return policy.load(fixturesNoQuotes).then(function (config) {
+test('expired policies do not strip (no quotes)', () => {
+  return policy.load(fixturesNoQuotes).then((config) => {
     const start = vulns.vulnerabilities.length;
-    t.ok(start > 0, 'we have vulns to start with');
+    expect(start).toBeGreaterThan(0);
 
     // should keep all vulns, because all of the ignores expired
     vulns = config.filter(vulns);
-    t.equal(vulns.ok, false, 'post filter, we still have vulns');
-    t.equal(vulns.vulnerabilities.length, start, 'all vulns remained');
+    expect(vulns.ok).toBe(false);
+    expect(vulns.vulnerabilities).toHaveLength(start);
   });
 });

--- a/test/unit/filter-ignore.test.ts
+++ b/test/unit/filter-ignore.test.ts
@@ -1,254 +1,216 @@
 import cloneDeep from 'lodash.clonedeep';
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import * as policy from '../../lib';
 import ignore from '../../lib/filter/ignore';
 
 const fixtures = __dirname + '/../fixtures/ignore';
 const vulns = require(fixtures + '/vulns.json');
 
-test('ignored vulns do not turn up in tests', function (t) {
-  policy
-    .load(fixtures)
-    .then(function (config) {
-      const start = vulns.vulnerabilities.length;
-      t.ok(vulns.vulnerabilities.length > 0, 'we have vulns to start with');
+test('ignored vulns do not turn up in tests', async () => {
+  const config = await policy.load(fixtures);
 
-      const filtered = [];
+  const start = vulns.vulnerabilities.length;
+  expect(vulns.vulnerabilities).length.greaterThan(0);
 
-      vulns.vulnerabilities = ignore(
-        config.ignore,
-        vulns.vulnerabilities,
-        filtered
-      );
+  const filtered = [];
 
-      // should strip 4
-      t.equal(
-        start - 4,
-        vulns.vulnerabilities.length,
-        'post filter: ' + vulns.vulnerabilities.length
-      );
-      t.equal(4, filtered.length, '4 vulns filtered');
-      const expected = {
-        'npm:hawk:20160119': [
-          {
-            reason: 'hawk got bumped',
-            expires: '2116-03-01T14:30:04.136Z',
-            path: ['sqlite', 'sqlite3', 'node-pre-gyp', 'request', 'hawk'],
-          },
-        ],
-        'npm:is-my-json-valid:20160118': [
-          {
-            reason: 'dev tool',
-            expires: '2116-03-01T14:30:04.136Z',
-            path: [
-              'sqlite',
-              'sqlite3',
-              'node-pre-gyp',
-              'request',
-              'har-validator',
-              'is-my-json-valid',
-            ],
-          },
-        ],
-        'npm:tar:20151103': [
-          {
-            reason: 'none given',
-            expires: '2116-03-01T14:30:04.137Z',
-            path: ['sqlite', 'sqlite3', 'node-pre-gyp', 'tar-pack', 'tar'],
-          },
-        ],
-        'npm:marked:20170907': [
-          {
-            reason: 'none given',
-            disregardIfFixable: true,
-            path: ['*'],
-          },
-        ],
-      };
-      const actual = filtered.reduce(function (actual, vuln: any) {
-        actual[vuln.id] = vuln.filtered.ignored;
-        return actual;
-      }, {});
-      t.same(actual, expected, 'filtered vulns include ignore rules');
+  vulns.vulnerabilities = ignore(
+    config.ignore,
+    vulns.vulnerabilities,
+    filtered
+  );
 
-      t.not(
-        vulns.vulnerabilities.every(function (vuln) {
-          return !!vuln.ignored;
-        }),
-        'vulns do not have ignored property'
-      );
+  // should strip 4
+  expect(start - 4).toBe(vulns.vulnerabilities.length);
+  expect(4).toBe(filtered.length);
+  const expected = {
+    'npm:hawk:20160119': [
+      {
+        reason: 'hawk got bumped',
+        expires: '2116-03-01T14:30:04.136Z',
+        path: ['sqlite', 'sqlite3', 'node-pre-gyp', 'request', 'hawk'],
+      },
+    ],
+    'npm:is-my-json-valid:20160118': [
+      {
+        reason: 'dev tool',
+        expires: '2116-03-01T14:30:04.136Z',
+        path: [
+          'sqlite',
+          'sqlite3',
+          'node-pre-gyp',
+          'request',
+          'har-validator',
+          'is-my-json-valid',
+        ],
+      },
+    ],
+    'npm:tar:20151103': [
+      {
+        reason: 'none given',
+        expires: '2116-03-01T14:30:04.137Z',
+        path: ['sqlite', 'sqlite3', 'node-pre-gyp', 'tar-pack', 'tar'],
+      },
+    ],
+    'npm:marked:20170907': [
+      {
+        reason: 'none given',
+        disregardIfFixable: true,
+        path: ['*'],
+      },
+    ],
+  };
+  const actual = filtered.reduce((actual, vuln: any) => {
+    actual[vuln.id] = vuln.filtered.ignored;
+    return actual;
+  }, {});
+  expect(actual).toStrictEqual(expected);
+
+  expect(
+    vulns.vulnerabilities.every((vuln) => {
+      return !!vuln.ignored;
     })
-    .catch(t.threw)
-    .then(t.end);
+  ).toBe(true);
 });
 
-test('vulns filtered by security policy ignores', function (t) {
+test('vulns filtered by security policy ignores', () => {
   const fixturesSecPolicy = __dirname + '/../fixtures/ignore-security-policy';
   const vulns = require(fixturesSecPolicy + '/vulns.json');
 
-  policy
-    .load(fixtures)
-    .then(function () {
-      const start = vulns.vulnerabilities.length;
-      t.ok(start > 0, `we have ${start} vulns to start with`);
+  policy.load(fixtures).then(() => {
+    const start = vulns.vulnerabilities.length;
+    expect(start).toBeGreaterThan(0);
 
-      const filtered = [];
+    const filtered = [];
 
-      vulns.vulnerabilities = ignore({}, vulns.vulnerabilities, filtered);
+    vulns.vulnerabilities = ignore({}, vulns.vulnerabilities, filtered);
 
-      t.equal(
-        start - 1,
-        vulns.vulnerabilities.length,
-        `vulns that were not filtered: ${vulns.vulnerabilities.length}`
-      );
-      t.equal(1, filtered.length, `${filtered.length} vuln filtered`);
+    expect(start - 1).toBe(vulns.vulnerabilities.length);
+    expect(filtered).toHaveLength(1);
 
-      const expected = {
-        'npm:tar:20151103': [
-          {
-            reason: '',
-            reasonType: 'wont-fix',
-            source: 'security-policy',
-            ignoredBy: {
-              id: '22A6B3BE-ABEF-4407-A634-AB1BE30A552F',
-              name: 'Ignored by Security Policy',
-            },
-            created: '2021-06-13T09:33:57.318Z',
-            disregardIfFixable: false,
-            path: ['*'],
+    const expected = {
+      'npm:tar:20151103': [
+        {
+          reason: '',
+          reasonType: 'wont-fix',
+          source: 'security-policy',
+          ignoredBy: {
+            id: '22A6B3BE-ABEF-4407-A634-AB1BE30A552F',
+            name: 'Ignored by Security Policy',
           },
-        ],
-      };
+          created: '2021-06-13T09:33:57.318Z',
+          disregardIfFixable: false,
+          path: ['*'],
+        },
+      ],
+    };
 
-      const actual = filtered.reduce(function (actual, vuln: any) {
-        actual[vuln.id] = vuln.filtered.ignored;
-        return actual;
-      }, {});
+    const actual = filtered.reduce((actual, vuln: any) => {
+      actual[vuln.id] = vuln.filtered.ignored;
+      return actual;
+    }, {});
 
-      t.same(actual, expected, 'filtered vuln includes ignore rules');
-    })
-    .catch(t.threw)
-    .then(t.end);
+    expect(actual).toStrictEqual(expected);
+  });
 });
 
-test('vulns filtered by security policy and config ignores', function (t) {
+test('vulns filtered by security policy and config ignores', async () => {
   const fixturesSecPolicy = __dirname + '/../fixtures/ignore-security-policy';
   const vulns = require(fixturesSecPolicy + '/vulns-security-metadata.json');
 
-  policy
-    .load(fixtures)
-    .then(function (config) {
-      const start = vulns.vulnerabilities.length;
-      t.ok(start > 0, `we have ${start} vulns to start with`);
+  const config = await policy.load(fixtures);
 
-      const filtered = [];
+  const start = vulns.vulnerabilities.length;
+  expect(start).toBeGreaterThan(0);
 
-      vulns.vulnerabilities = ignore(
-        config.ignore,
-        vulns.vulnerabilities,
-        filtered
-      );
+  const filtered = [];
 
-      t.equal(
-        start - 4,
-        vulns.vulnerabilities.length,
-        `vulns that were not filtered: 0`
-      );
+  vulns.vulnerabilities = ignore(
+    config.ignore,
+    vulns.vulnerabilities,
+    filtered
+  );
 
-      t.equal(filtered.length, 4, `${filtered.length} vuln filtered`);
+  expect(start - 4).toBe(vulns.vulnerabilities.length);
+  expect(filtered).toHaveLength(4);
 
-      const expected = {
-        'npm:hawk:20160119': [
-          {
-            reason: 'hawk got bumped',
-            expires: '2116-03-01T14:30:04.136Z',
-            path: ['sqlite', 'sqlite3', 'node-pre-gyp', 'request', 'hawk'],
-          },
+  const expected = {
+    'npm:hawk:20160119': [
+      {
+        reason: 'hawk got bumped',
+        expires: '2116-03-01T14:30:04.136Z',
+        path: ['sqlite', 'sqlite3', 'node-pre-gyp', 'request', 'hawk'],
+      },
+    ],
+    'npm:is-my-json-valid:20160118': [
+      {
+        reason: 'dev tool',
+        expires: '2116-03-01T14:30:04.136Z',
+        path: [
+          'sqlite',
+          'sqlite3',
+          'node-pre-gyp',
+          'request',
+          'har-validator',
+          'is-my-json-valid',
         ],
-        'npm:is-my-json-valid:20160118': [
-          {
-            reason: 'dev tool',
-            expires: '2116-03-01T14:30:04.136Z',
-            path: [
-              'sqlite',
-              'sqlite3',
-              'node-pre-gyp',
-              'request',
-              'har-validator',
-              'is-my-json-valid',
-            ],
-          },
-        ],
-        'npm:tar:20151103': [
-          {
-            reason: '',
-            reasonType: 'wont-fix',
-            source: 'security-policy',
-            ignoredBy: {
-              id: '22A6B3BE-ABEF-4407-A634-AB1BE30A552F',
-              name: 'Ignored by Security Policy',
-            },
-            created: '2021-06-13T09:33:57.318Z',
-            disregardIfFixable: false,
-            path: ['*'],
-          },
-        ],
-        'npm:marked:20170907': [
-          {
-            reason: 'none given',
-            disregardIfFixable: true,
-            path: ['*'],
-          },
-        ],
-      };
+      },
+    ],
+    'npm:tar:20151103': [
+      {
+        reason: '',
+        reasonType: 'wont-fix',
+        source: 'security-policy',
+        ignoredBy: {
+          id: '22A6B3BE-ABEF-4407-A634-AB1BE30A552F',
+          name: 'Ignored by Security Policy',
+        },
+        created: '2021-06-13T09:33:57.318Z',
+        disregardIfFixable: false,
+        path: ['*'],
+      },
+    ],
+    'npm:marked:20170907': [
+      {
+        reason: 'none given',
+        disregardIfFixable: true,
+        path: ['*'],
+      },
+    ],
+  };
 
-      const actual = filtered.reduce(function (actual, vuln: any) {
-        actual[vuln.id] = vuln.filtered.ignored;
-        return actual;
-      }, {});
+  const actual = filtered.reduce((actual, vuln: any) => {
+    actual[vuln.id] = vuln.filtered.ignored;
+    return actual;
+  }, {});
 
-      t.same(
-        actual,
-        expected,
-        'filtered vuln includes ignore rules from security policies and config'
-      );
-    })
-    .catch(t.threw)
-    .then(t.end);
+  expect(actual).toStrictEqual(expected);
 });
 
-test('does not accept incomplete security policy to ignore vulns', function (t) {
+test('does not accept incomplete security policy to ignore vulns', async () => {
   const fixturesSecPolicy = __dirname + '/../fixtures/ignore-security-policy';
   const vulns = require(fixturesSecPolicy +
     '/vulns-incomplete-security-metadata.json');
 
-  policy
-    .load(fixtures)
-    .then(function (config) {
-      const start = vulns.vulnerabilities.length;
-      t.ok(vulns.vulnerabilities.length > 0, 'we have vulns to start with');
+  const config = await policy.load(fixtures);
 
-      const filtered = [];
+  const start = vulns.vulnerabilities.length;
+  expect(vulns.vulnerabilities).length.greaterThan(0);
 
-      vulns.vulnerabilities = ignore(
-        config.ignore,
-        vulns.vulnerabilities,
-        filtered
-      );
+  const filtered = [];
 
-      // should strip 4
-      t.equal(
-        start - 4,
-        vulns.vulnerabilities.length,
-        'vulns that were not filtered: ' + vulns.vulnerabilities.length
-      );
-      t.equal(4, filtered.length, '4 vulns filtered');
-    })
-    .catch(t.threw)
-    .then(t.end);
+  vulns.vulnerabilities = ignore(
+    config.ignore,
+    vulns.vulnerabilities,
+    filtered
+  );
+
+  // should strip 4
+  expect(start - 4).toBe(vulns.vulnerabilities.length);
+  expect(filtered).toHaveLength(4);
 });
 
-test('filters vulnerabilities by exact match', function (t) {
+test('filters vulnerabilities by exact match', async () => {
   const vulns = {
     vulnerabilities: [
       {
@@ -269,12 +231,8 @@ test('filters vulnerabilities by exact match', function (t) {
   const expected = cloneDeep(vulns);
   expected.vulnerabilities.splice(1, 1);
 
-  policy
-    .load(__dirname + '/../fixtures/ignore-exact')
-    .then(function (config) {
-      const filtered = config.filter(vulns, undefined, 'exact');
-      t.same(filtered.vulnerabilities, expected.vulnerabilities);
-    })
-    .catch(t.threw)
-    .then(t.end);
+  const config = await policy.load(__dirname + '/../fixtures/ignore-exact');
+
+  const filtered = config.filter(vulns, undefined, 'exact');
+  expect(filtered.vulnerabilities).toStrictEqual(expected.vulnerabilities);
 });

--- a/test/unit/filter-notes.test.ts
+++ b/test/unit/filter-notes.test.ts
@@ -1,45 +1,30 @@
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 
 const fixtures = __dirname + '/../fixtures';
 const vulns = require(fixtures + '/patch/vulns.json');
 
-// mock the vulns
-vulns.vulnerabilities.forEach(function (v) {
-  // v.from.unshift('ignore@1.0.0');
-});
-
 import * as policy from '../../lib';
 import notes from '../../lib/filter/notes';
 
-test('ignored vulns do not turn up in tests', function (t) {
-  return policy
-    .load([fixtures + '/patch', fixtures + '/deep-policy'])
-    .then(function (res) {
-      const start = vulns.vulnerabilities.length;
-      t.ok(vulns.vulnerabilities.length > 0, 'we have vulns to start with');
-      t.ok(res.suggest, 'has suggestions');
+test('ignored vulns do not turn up in tests', async () => {
+  const res = await policy.load([
+    fixtures + '/patch',
+    fixtures + '/deep-policy',
+  ]);
 
-      // FIXME patch vulns doesn't match anything in the ignore/.snyk
-      vulns.vulnerabilities = notes(res.suggest, vulns.vulnerabilities);
+  const start = vulns.vulnerabilities.length;
+  expect(vulns.vulnerabilities).length.greaterThan(0);
+  expect(res.suggest).toBeTruthy();
 
-      t.equal(
-        start,
-        vulns.vulnerabilities.length,
-        'post filter nothing changed'
-      );
-      const items = vulns.vulnerabilities
-        .map(function (e) {
-          return e.note;
-        })
-        .filter(Boolean);
+  // FIXME patch vulns doesn't match anything in the ignore/.snyk
+  vulns.vulnerabilities = notes(res.suggest, vulns.vulnerabilities);
 
-      t.equal(items.length, 1, 'one has a note');
+  expect(start).toBe(vulns.vulnerabilities.length);
 
-      t.match(items[0], new RegExp(vulns.name), 'found package name');
-      t.notMatch(
-        items[0],
-        new RegExp('undefined'),
-        'undefined does not appear'
-      );
-    });
+  const items = vulns.vulnerabilities.map((e) => e.note).filter(Boolean);
+
+  expect(items).toHaveLength(1);
+
+  expect(items[0]).toMatch(new RegExp(vulns.name));
+  expect(items[0]).not.toMatch(new RegExp('undefined'));
 });

--- a/test/unit/filter.test.ts
+++ b/test/unit/filter.test.ts
@@ -1,16 +1,15 @@
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import * as policy from '../../lib';
 
 const fixtures = __dirname + '/../fixtures/ignore';
 let vulns = require(fixtures + '/vulns.json');
 
-test('ignored vulns do not turn up in tests', function (t) {
-  return policy.load(fixtures).then(function (config) {
-    t.ok(vulns.vulnerabilities.length > 0, 'we have vulns to start with');
+test('ignored vulns do not turn up in tests', async () => {
+  const config = await policy.load(fixtures);
+  expect(vulns.vulnerabilities).length.greaterThan(0);
 
-    // should strip all
-    vulns = config.filter(vulns);
-    t.equal(vulns.ok, true, 'post filter, we have no vulns');
-    t.same(vulns.vulnerabilities, [], 'vulns stripped');
-  });
+  // should strip all
+  vulns = config.filter(vulns);
+  expect(vulns.ok).toBe(true);
+  expect(vulns.vulnerabilities).toStrictEqual([]);
 });

--- a/test/unit/ignore-policy.test.ts
+++ b/test/unit/ignore-policy.test.ts
@@ -1,24 +1,25 @@
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import * as policy from '../../lib';
 
 const fixtures = __dirname + '/../fixtures';
 
-test('single load', function (t) {
-  return policy
-    .load(fixtures + '/ignore', { 'ignore-policy': true })
-    .then(function (res) {
-      t.equal(Object.keys(res.ignore).length, 0, 'ignore policy is empty');
-      t.equal(Object.keys(res.patch).length, 0, 'patch policy is empty');
-      t.type(res.filter, 'function', 'helper methods attached');
-    });
+test('single load', async () => {
+  const res = await policy.load(fixtures + '/ignore', {
+    'ignore-policy': true,
+  });
+
+  expect(Object.keys(res.ignore)).toHaveLength(0);
+  expect(Object.keys(res.patch)).toHaveLength(0);
+  expect(res.filter).toBeTypeOf('function');
 });
 
-test('multiple load', function (t) {
-  return policy
-    .load([fixtures + '/patch', fixtures + '/patch-mean'])
-    .then(function (res) {
-      t.equal(Object.keys(res.ignore).length, 0, 'ignore policy is empty');
-      t.not(Object.keys(res.patch).length, 0, 'patch policy is not empty');
-      t.type(res.filter, 'function', 'helper methods attached');
-    });
+test('multiple load', async () => {
+  const res = await policy.load([
+    fixtures + '/patch',
+    fixtures + '/patch-mean',
+  ]);
+
+  expect(Object.keys(res.ignore)).toHaveLength(0);
+  expect(Object.keys(res.patch)).not.toHaveLength(0);
+  expect(res.filter).toBeTypeOf('function');
 });

--- a/test/unit/match.test.ts
+++ b/test/unit/match.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import test from 'tap-only';
+import { describe, expect, test } from 'vitest';
 import * as policy from '../../lib';
 
 const fixtures = __dirname + '/../fixtures';
@@ -11,7 +11,7 @@ const exactMatchVuln = {
   from: ['a-dir/a-file.json', 'foo', 'bar'],
 };
 
-test('matchToRule', function (t) {
+describe('matchToRule', () => {
   const vuln = {
     from: [
       'projectName', // this is ignored
@@ -21,265 +21,324 @@ test('matchToRule', function (t) {
     ],
   };
 
-  const tt = {
-    'match exact path': {
-      rule: {
-        'jsbin@3.35.9 > handlebars@2.0.0 > uglify-js@2.3.6': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
+  test('match exact path', () => {
+    const rule = {
+      'jsbin@3.35.9 > handlebars@2.0.0 > uglify-js@2.3.6': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
       },
-      match: true,
-    },
-    'match without versions': {
-      rule: {
-        'jsbin > handlebars > uglify-js': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'match mixed version and versionless': {
-      rule: {
-        'jsbin > handlebars@2.0.0 > uglify-js@2.3.6': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'match on only root dependency': {
-      rule: {
-        'jsbin@3.35.9': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'match on first few dependencies': {
-      rule: {
-        'jsbin@3.35.9 > handlebars@2.0.0': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'match with multiple paths': {
-      rule: {
-        'express-hbs > handlebars > uglify-js': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-        'jsbin > handlebars > uglify-js': {
-          reason: 'done this already',
-          expires: '2016-03-01T19:53:46.310Z',
-        },
-      },
-      match: true,
-    },
-    'match all paths with star': {
-      rule: {
-        '*': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'match star at start': {
-      rule: {
-        '* > handlebars@2.0.0 > uglify-js@2.3.6': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'match star in middle': {
-      rule: {
-        'jsbin@3.35.9 > * > uglify-js@2.3.6': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'match star at end': {
-      rule: {
-        'jsbin > handlebars@2.0.0 > *': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'match star at start and end': {
-      rule: {
-        '* > handlebars@2.0.0 > *': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'match star for multiple dependencies': {
-      rule: {
-        '* > uglify-js': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'match on star version': {
-      rule: {
-        'jsbin@3.35.9 > handlebars@* > uglify-js@2.3.6': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'match on star dependency and star version': {
-      rule: {
-        '* > handlebars@* > uglify-js@2.3.6': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'match on multiple star versions': {
-      rule: {
-        '* > handlebars@* > uglify-js@*': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'match on version range': {
-      rule: {
-        'jsbin@3.35.9 > handlebars@>1.1.0 <2.1.0 > uglify-js@2.3.6': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'match on x range': {
-      rule: {
-        'jsbin@3.35.9 > handlebars@2.x > uglify-js@2.3.6': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'match on caret range': {
-      rule: {
-        'jsbin@3.35.9 > handlebars@^2.0.0 > uglify-js@2.3.6': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: true,
-    },
-    'no match on different path': {
-      rule: {
-        'nyc@11.9.0 > istanbul-lib-report@1.1.3 > path-parse@1.0.5': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: false,
-    },
-    'no match for different root': {
-      rule: {
-        'express-hbs > handlebars > uglify-js': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: false,
-    },
-    'no match on subpath': {
-      rule: {
-        'handlebars@2.0.0 > uglify-js@2.3.6': {
-          reason: 'done this already',
-          expires: '2016-03-01T19:53:46.310Z',
-        },
-      },
-      match: false,
-    },
-    'no match on single dependency in path': {
-      rule: {
-        'handlebars@2.0.0': {
-          reason: 'done this already',
-          expires: '2016-03-01T19:53:46.310Z',
-        },
-      },
-      match: false,
-    },
-    'no match for different root version': {
-      rule: {
-        'jsbin@1.0.0 > handlebars@2.0.0 > uglify-js@2.3.6': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: false,
-    },
-    'no match for different transitive version': {
-      rule: {
-        'jsbin@3.35.9 > handlebars@1.0.0 > uglify-js@2.3.6': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: false,
-    },
-    'no match with star': {
-      rule: {
-        '* > moment': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: false,
-    },
-    'no match on multiple stars': {
-      rule: {
-        '* > * > uglify-js@2.3.6': {
-          reason: 'None given',
-          expires: '2016-03-01T19:49:50.633Z',
-        },
-      },
-      match: false,
-    },
-  };
+    };
 
-  for (var [name, test] of Object.entries(tt)) {
-    t.test(name, (st) => {
-      const pathMatch = policy.matchToRule(vuln, test.rule);
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
 
-      if (test.match) {
-        st.ok(pathMatch, 'vuln matches rule');
-      } else {
-        st.notOk(pathMatch, 'correctly does not match');
-      }
+  test('match without versions', () => {
+    const rule = {
+      'jsbin > handlebars > uglify-js': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
 
-      st.end();
-    });
-  }
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
 
-  t.end();
+  test('match mixed version and versionless', () => {
+    const rule = {
+      'jsbin > handlebars@2.0.0 > uglify-js@2.3.6': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('match on only root dependency', () => {
+    const rule = {
+      'jsbin@3.35.9': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('match on first few dependencies', () => {
+    const rule = {
+      'jsbin@3.35.9 > handlebars@2.0.0': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('match with multiple paths', () => {
+    const rule = {
+      'express-hbs > handlebars > uglify-js': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+      'jsbin > handlebars > uglify-js': {
+        reason: 'done this already',
+        expires: '2016-03-01T19:53:46.310Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('match all paths with star', () => {
+    const rule = {
+      '*': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('match star at start', () => {
+    const rule = {
+      '* > handlebars@2.0.0 > uglify-js@2.3.6': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('match star in middle', () => {
+    const rule = {
+      'jsbin@3.35.9 > * > uglify-js@2.3.6': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('match star at end', () => {
+    const rule = {
+      'jsbin > handlebars@2.0.0 > *': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('match star at start and end', () => {
+    const rule = {
+      '* > handlebars@2.0.0 > *': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('match star for multiple dependencies', () => {
+    const rule = {
+      '* > uglify-js': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('match on star version', () => {
+    const rule = {
+      'jsbin@3.35.9 > handlebars@* > uglify-js@2.3.6': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('match on star dependency and star version', () => {
+    const rule = {
+      '* > handlebars@* > uglify-js@2.3.6': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('match on multiple star versions', () => {
+    const rule = {
+      '* > handlebars@* > uglify-js@*': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('match on version range', () => {
+    const rule = {
+      'jsbin@3.35.9 > handlebars@>1.1.0 <2.1.0 > uglify-js@2.3.6': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('match on x range', () => {
+    const rule = {
+      'jsbin@3.35.9 > handlebars@2.x > uglify-js@2.3.6': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('match on caret range', () => {
+    const rule = {
+      'jsbin@3.35.9 > handlebars@^2.0.0 > uglify-js@2.3.6': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
+
+  test('no match on different path', () => {
+    const rule = {
+      'nyc@11.9.0 > istanbul-lib-report@1.1.3 > path-parse@1.0.5': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeFalsy();
+  });
+
+  test('no match for different root', () => {
+    const rule = {
+      'express-hbs > handlebars > uglify-js': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeFalsy();
+  });
+
+  test('no match on subpath', () => {
+    const rule = {
+      'handlebars@2.0.0 > uglify-js@2.3.6': {
+        reason: 'done this already',
+        expires: '2016-03-01T19:53:46.310Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeFalsy();
+  });
+
+  test('no match on single dependency in path', () => {
+    const rule = {
+      'handlebars@2.0.0': {
+        reason: 'done this already',
+        expires: '2016-03-01T19:53:46.310Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeFalsy();
+  });
+
+  test('no match for different root version', () => {
+    const rule = {
+      'jsbin@1.0.0 > handlebars@2.0.0 > uglify-js@2.3.6': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeFalsy();
+  });
+
+  test('no match for different transitive version', () => {
+    const rule = {
+      'jsbin@3.35.9 > handlebars@1.0.0 > uglify-js@2.3.6': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeFalsy();
+  });
+
+  test('no match with star', () => {
+    const rule = {
+      '* > moment': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeFalsy();
+  });
+
+  test('no match on multiple stars', () => {
+    const rule = {
+      '* > * > uglify-js@2.3.6': {
+        reason: 'None given',
+        expires: '2016-03-01T19:49:50.633Z',
+      },
+    };
+
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeFalsy();
+  });
 });
 
-test('matchToRule long', function (t) {
+describe('matchToRule long', () => {
   const vuln = {
     from: [
       'test',
@@ -290,47 +349,34 @@ test('matchToRule long', function (t) {
     ],
   };
 
-  const tt = {
-    one: {
-      rule: {
-        'org.apache.kafka:kafka_2.13@2.7.1 > org.apache.zookeeper:zookeeper@3.5.9 > io.netty:netty-handler@4.1.50.Final > io.netty:netty-codec@4.1.50.Final':
-          {
-            reason: 'None given',
-            expires: '2016-03-01T19:49:50.633Z',
-          },
-      },
-      match: true,
-    },
-    two: {
-      rule: {
-        'org.apache.kafka:kafka_2.13@2.7.1 > org.apache.zookeeper:zookeeper@>=3.5.0 <3.6.0 > io.netty:netty-handler@4.1.50.Final > io.netty:netty-codec@4.1.50.Final':
-          {
-            reason: 'done this already',
-            expires: '2016-03-01T19:53:46.310Z',
-          },
-      },
-      match: true,
-    },
-  };
+  test('one', () => {
+    const rule = {
+      'org.apache.kafka:kafka_2.13@2.7.1 > org.apache.zookeeper:zookeeper@3.5.9 > io.netty:netty-handler@4.1.50.Final > io.netty:netty-codec@4.1.50.Final':
+        {
+          reason: 'None given',
+          expires: '2016-03-01T19:49:50.633Z',
+        },
+    };
 
-  for (var [name, test] of Object.entries(tt)) {
-    t.test(name, (st) => {
-      const pathMatch = policy.matchToRule(vuln, test.rule);
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
 
-      if (test.match) {
-        st.ok(pathMatch, 'vuln matches rule');
-      } else {
-        st.notOk(pathMatch, 'correctly does not match');
-      }
+  test('two', () => {
+    const rule = {
+      'org.apache.kafka:kafka_2.13@2.7.1 > org.apache.zookeeper:zookeeper@>=3.5.0 <3.6.0 > io.netty:netty-handler@4.1.50.Final > io.netty:netty-codec@4.1.50.Final':
+        {
+          reason: 'done this already',
+          expires: '2016-03-01T19:53:46.310Z',
+        },
+    };
 
-      st.end();
-    });
-  }
-
-  t.end();
+    const pathMatch = policy.matchToRule(vuln, rule);
+    expect(pathMatch).toBeTruthy();
+  });
 });
 
-test('match (triggering not found)', function (t) {
+test('match (triggering not found)', () => {
   const vuln = require(fixtures + '/path-not-found.json');
   const rule = {
     'glue > hapi > joi > moment': {
@@ -339,11 +385,10 @@ test('match (triggering not found)', function (t) {
   };
 
   const pathMatch = policy.matchToRule(vuln, rule);
-  t.equal(pathMatch, false, 'path does not match');
-  t.end();
+  expect(pathMatch).toBe(false);
 });
 
-test('rule with git url as dependency', function (t) {
+test('rule with git url as dependency', () => {
   const rule = {
     'patchable-vuln > qs': {
       patched: '2018-11-04T12:47:13.696Z',
@@ -351,56 +396,50 @@ test('rule with git url as dependency', function (t) {
   };
 
   const pathMatch = policy.matchToRule(vulnWithGitUrl, rule);
-  t.ok(pathMatch, 'vuln matches rule');
-  t.end();
+  expect(pathMatch).toBeTruthy();
 });
 
-test('exact match  does not match when path arrays are not equal', function (t) {
+test('exact match  does not match when path arrays are not equal', () => {
   const rule = {
     'a-dir/a-file.json': {},
   };
 
   const pathMatch = policy.matchToRule(exactMatchVuln, rule, 'exact');
-  t.notOk(pathMatch, 'does not match when path arrays are not equal');
-  t.end();
+  expect(pathMatch).toBeFalsy();
 });
 
-test('exact match  matches when path arrays are equal', function (t) {
+test('exact match  matches when path arrays are equal', () => {
   const rule = {
     'a-dir/a-file.json > foo > bar': {},
   };
 
   const pathMatch = policy.matchToRule(exactMatchVuln, rule, 'exact');
-  t.ok(pathMatch, 'vuln matches rule');
-  t.end();
+  expect(pathMatch).toBeTruthy();
 });
 
-test('exact match  matches when rule is *', function (t) {
+test('exact match  matches when rule is *', () => {
   const rule = {
     '*': {},
   };
 
   const pathMatch = policy.matchToRule(exactMatchVuln, rule, 'exact');
-  t.ok(pathMatch, 'vuln matches rule');
-  t.end();
+  expect(pathMatch).toBeTruthy();
 });
 
-test('exact match  matches when path matches before *', function (t) {
+test('exact match  matches when path matches before *', () => {
   const rule = {
     'a-dir/a-file.json > *': {},
   };
 
   const pathMatch = policy.matchToRule(exactMatchVuln, rule, 'exact');
-  t.ok(pathMatch, 'vuln matches rule');
-  t.end();
+  expect(pathMatch).toBeTruthy();
 });
 
-test('exact match  does not match when path does not match before *', function (t) {
+test('exact match  does not match when path does not match before *', () => {
   const rule = {
     'a-dir/a-file.json > wrong > *': {},
   };
 
   const pathMatch = policy.matchToRule(exactMatchVuln, rule, 'exact');
-  t.notOk(pathMatch, 'correctly does not match');
-  t.end();
+  expect(pathMatch).toBeFalsy();
 });

--- a/test/unit/old-format.test.ts
+++ b/test/unit/old-format.test.ts
@@ -1,17 +1,12 @@
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import * as policy from '../../lib';
 
-test('test sensibly bails if gets an old .snyk format', function (t) {
-  return policy
-    .load(__dirname + '/../fixtures/old-snyk-config/')
-    .then(function () {
-      return true;
+test('test sensibly bails if gets an old .snyk format', () => {
+  expect(() =>
+    policy.load(__dirname + '/../fixtures/old-snyk-config/').catch((e) => {
+      expect(e.message).toBe('old, unsupported .snyk format detected');
+      expect(e.code).toBe('OLD_DOTFILE_FORMAT');
+      throw e;
     })
-    .then(function (res) {
-      t.fail('was expecting an error, got ' + JSON.stringify(res));
-    })
-    .catch(function (e) {
-      t.equal(e.message, 'old, unsupported .snyk format detected');
-      t.equal(e.code, 'OLD_DOTFILE_FORMAT');
-    });
+  ).rejects.toThrow();
 });

--- a/test/unit/parser-add-comments.test.ts
+++ b/test/unit/parser-add-comments.test.ts
@@ -1,38 +1,30 @@
 import * as yaml from 'js-yaml';
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import addComments from '../../lib/parser/add-comments';
 
-test('policy with no patches or ignores', function (t) {
+test('policy with no patches or ignores', () => {
   const res = addComments(
-    yaml.safeDump({
+    yaml.dump({
       version: 'v1.0.0',
       patch: {},
       ignore: {},
     })
   );
 
-  t.ok(
-    res.match(/^# Snyk \(https:\/\/snyk\.io\) policy file/),
-    'addComments adds initial comment'
-  );
-  t.notMatch(
-    res,
+  expect(res).toMatch(/^# Snyk \(https:\/\/snyk\.io\) policy file/);
+  expect(res).not.toMatch(
     '# patches apply the minimum changes required to fix ' +
-      'a vulnerability\npatch:',
-    'addComments does not add patch comment'
+      'a vulnerability\npatch:'
   );
-  t.notMatch(
-    res,
+  expect(res).not.toMatch(
     '# ignores vulnerabilities until expiry date; change ' +
-      'duration by modifying expiry date\nignore:',
-    'addComments does not add ignore comment'
+      'duration by modifying expiry date\nignore:'
   );
-  t.end();
 });
 
-test('policy with patches', function (t) {
+test('policy with patches', () => {
   const res = addComments(
-    yaml.safeDump({
+    yaml.dump({
       version: 'v1.0.0',
       patch: {
         'glue > hapi > joi > moment': [
@@ -45,24 +37,19 @@ test('policy with patches', function (t) {
     })
   );
 
-  t.match(
-    res,
+  expect(res).toMatch(
     '# patches apply the minimum changes required to fix ' +
-      'a vulnerability\npatch:',
-    'addComments adds patch comment'
+      'a vulnerability\npatch:'
   );
-  t.notMatch(
-    res,
+  expect(res).not.toMatch(
     '# ignores vulnerabilities until expiry date; change ' +
-      'duration by modifying expiry date\nignore:',
-    'addComments does not add ignore comment'
+      'duration by modifying expiry date\nignore:'
   );
-  t.end();
 });
 
-test('policy with ignores', function (t) {
+test('policy with ignores', () => {
   const res = addComments(
-    yaml.safeDump({
+    yaml.dump({
       version: 'v1.0.0',
       patch: {},
       ignore: {
@@ -75,24 +62,19 @@ test('policy with ignores', function (t) {
     })
   );
 
-  t.match(
-    res,
+  expect(res).toMatch(
     '# ignores vulnerabilities until expiry date; change ' +
-      'duration by modifying expiry date\nignore:',
-    'addComments adds ignore comment'
+      'duration by modifying expiry date\nignore:'
   );
-  t.notMatch(
-    res,
+  expect(res).not.toMatch(
     '# patches apply the minimum changes required to fix ' +
-      'a vulnerability\npatch:',
-    'addComments does not add patch comment'
+      'a vulnerability\npatch:'
   );
-  t.end();
 });
 
-test('policy with ignores and patches', function (t) {
+test('policy with ignores and patches', () => {
   const res = addComments(
-    yaml.safeDump({
+    yaml.dump({
       version: 'v1.0.0',
       patch: {
         'glue > hapi > joi > moment': [
@@ -111,17 +93,12 @@ test('policy with ignores and patches', function (t) {
     })
   );
 
-  t.match(
-    res,
+  expect(res).toMatch(
     '# ignores vulnerabilities until expiry date; change ' +
-      'duration by modifying expiry date\nignore:',
-    'addComments adds ignore comment'
+      'duration by modifying expiry date\nignore:'
   );
-  t.match(
-    res,
+  expect(res).toMatch(
     '# patches apply the minimum changes required to fix ' +
-      'a vulnerability\npatch:',
-    'addComments adds patch comment'
+      'a vulnerability\npatch:'
   );
-  t.end();
 });

--- a/test/unit/parser.test.ts
+++ b/test/unit/parser.test.ts
@@ -1,35 +1,33 @@
 import * as yaml from 'js-yaml';
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import * as parser from '../../lib/parser';
 
 const fixtures = __dirname + '/../fixtures';
 
-test('parser fills out defaults', function (t) {
+test('parser fills out defaults', () => {
   const res = parser.import();
-  const expect = {
+  const expected = {
     version: 'v1.0.0',
     ignore: {},
     patch: {},
   };
 
-  t.same(res, expect, 'parser fills defaults');
-  t.end();
+  expect(res).toStrictEqual(expected);
 });
 
-test('parser fills out defaults for invalid inputs', function (t) {
+test('parser fills out defaults for invalid inputs', () => {
   const res = parser.import('test');
-  const expect = {
+  const expected = {
     version: 'v1.0.0',
     ignore: {},
     patch: {},
   };
 
-  t.same(res, expect, 'parser fills defaults for invalid inputs');
-  t.end();
+  expect(res).toStrictEqual(expected);
 });
 
-test('parser does not modify default parsed format', function (t) {
-  const expect = {
+test('parser does not modify default parsed format', () => {
+  const expected = {
     version: 'v1.0.0',
     patch: {
       'glue > hapi > joi > moment': [
@@ -41,59 +39,36 @@ test('parser does not modify default parsed format', function (t) {
     ignore: {},
   };
 
-  const res = parser.import(yaml.safeDump(expect));
+  const res = parser.import(yaml.dump(expected));
 
-  t.same(res, expect, 'parser does nothing extra (v1 vs v1)');
-  t.end();
+  expect(res).toStrictEqual(expected);
 });
 
-test('test unsupported version', function (t) {
-  t.throws(
-    function () {
-      parser.import(
-        yaml.safeDump({
-          version: 'v20.0.1',
-        })
-      );
-    },
-    /unsupported version/,
-    'unsupported version throws'
-  );
-  t.end();
+test('test unsupported version', () => {
+  expect(() => {
+    parser.import(
+      yaml.dump({
+        version: 'v20.0.1',
+      })
+    );
+  }).toThrow(/unsupported version/);
 });
 
-test('demunge', function (t) {
+test('demunge', () => {
   const source = require(fixtures + '/parsed.json');
   const res = parser.demunge(source);
   const patchIds = Object.keys(source.patch);
   const ignoreIds = Object.keys(source.ignore);
   const excludeIds = Object.keys(source.exclude);
-  t.ok(Array.isArray(res.ignore), 'array');
-  t.ok(Array.isArray(res.patch), 'array');
-  t.ok(Array.isArray(res.exclude), 'array');
-  t.equal(res.patch.length, 2, 'two patched items');
-  t.equal(res.ignore.length, 3, 'three ignored items');
-  t.equal(res.exclude.length, 2, 'two excluded categories');
-  t.same(
-    res.patch.map(function (o) {
-      return o.id;
-    }),
-    patchIds,
-    'patch ids found in the right place'
-  );
-  t.same(
-    res.ignore.map(function (o) {
-      return o.id;
-    }),
-    ignoreIds,
-    'ignore ids found in the right place'
-  );
-  t.same(
-    res.exclude.map(function (o) {
-      return o.id;
-    }),
-    excludeIds,
-    'exclude ids found in the right place'
-  );
-  t.end();
+
+  expect(res.ignore).toBeInstanceOf(Array);
+  expect(res.patch).toBeInstanceOf(Array);
+  expect(res.exclude).toBeInstanceOf(Array);
+  expect(res.patch).toHaveLength(2);
+  expect(res.ignore).toHaveLength(3);
+  expect(res.exclude).toHaveLength(2);
+
+  expect(res.patch.map((o) => o.id)).toStrictEqual(patchIds);
+  expect(res.ignore.map((o) => o.id)).toStrictEqual(ignoreIds);
+  expect(res.exclude.map((o) => o.id)).toStrictEqual(excludeIds);
 });

--- a/test/unit/policy-parse.test.ts
+++ b/test/unit/policy-parse.test.ts
@@ -1,29 +1,29 @@
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import * as policy from '../../lib';
 
 const fixtures = __dirname + '/../fixtures/issues/SC-1106/';
 const withoutDash = fixtures + '/missing-dash.snyk';
 const withDash = fixtures + '/with-dash.snyk';
 
-test('missing dash on policy is fixed up', function (t) {
+test('missing dash on policy is fixed up', () => {
   const p1 = policy.load(withoutDash);
   const p2 = policy.load(withDash);
 
   const key = 'npm:hawk:20160119';
 
-  return Promise.all([p1, p2]).then(function (res) {
+  return Promise.all([p1, p2]).then((res) => {
     const paths1 = getPaths(res[0].ignore[key]);
     const paths2 = getPaths(res[1].ignore[key]);
 
-    t.equal(paths1.length, 3, 'has 3 paths');
-    t.equal(paths1.length, paths2.length, 'has equal length');
-    t.same(paths1, paths2, 'missing dash was hotfixed');
+    expect(paths1).toHaveLength(3);
+    expect(paths1).toHaveLength(paths2.length);
+    expect(paths1).toStrictEqual(paths2);
   });
 });
 
 function getPaths(rules) {
   return rules
-    .map(function (rule) {
+    .map((rule) => {
       const keys = Object.keys(rule);
       if (keys.length === 1) {
         return keys.shift();

--- a/test/unit/policy.test.ts
+++ b/test/unit/policy.test.ts
@@ -1,222 +1,198 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
-import test from 'tap-only';
+import { expect, test } from 'vitest';
 import * as policy from '../../lib';
 
 const fixtures = __dirname + '/../fixtures';
 
-test('module loads', function (t) {
-  t.type(policy, 'object', 'policy has loaded an object');
-  t.end();
+test('module loads', () => {
+  expect(policy).toBeTypeOf('object');
 });
 
-test('policy.load (single)', function (t) {
-  return policy.load(fixtures + '/simple').then(function (res) {
-    const expect = {
-      version: 'v1.0.0',
-      ignore: {},
-      patch: {},
-      __filename: path.relative(process.cwd(), fixtures + '/simple/.snyk'),
-      __modified: res.__modified ? new Date(res.__modified) : false,
-      __created: res.__created ? new Date(res.__created) : false,
-    };
+test('policy.load (single)', async () => {
+  const res = await policy.load(fixtures + '/simple');
+  const expected = {
+    version: 'v1.0.0',
+    ignore: {},
+    patch: {},
+    __filename: path.relative(process.cwd(), fixtures + '/simple/.snyk'),
+    __modified: res.__modified ? new Date(res.__modified) : false,
+    __created: res.__created ? new Date(res.__created) : false,
+  };
 
-    stripFunctions(res);
+  stripFunctions(res);
 
-    t.same(res, expect, 'policy is as expected');
+  expect(res).toStrictEqual(expected);
+});
+
+test('policy.load (single .snyk in path name)', async () => {
+  const res = await policy.load(fixtures + '/project.snyk');
+
+  const expected = {
+    version: 'v1.0.0',
+    ignore: {},
+    patch: {},
+    __filename: path.relative(process.cwd(), fixtures + '/project.snyk/.snyk'),
+    __modified: res.__modified ? new Date(res.__modified) : false,
+    __created: res.__created ? new Date(res.__created) : false,
+  };
+
+  stripFunctions(res);
+
+  expect(res).toStrictEqual(expected);
+});
+
+test('policy.load (double .snyk in path name)', async () => {
+  const res = await policy.load(fixtures + '/project.snyk/project1.snyk');
+
+  const expected = {
+    version: 'v1.0.0',
+    ignore: {},
+    patch: {},
+    __filename: path.relative(
+      process.cwd(),
+      fixtures + '/project.snyk/project1.snyk/.snyk'
+    ),
+    __modified: res.__modified ? new Date(res.__modified) : false,
+    __created: res.__created ? new Date(res.__created) : false,
+  };
+
+  stripFunctions(res);
+
+  expect(res).toStrictEqual(expected);
+});
+
+test('policy.load (single .snyk in path name but at upper level)', async () => {
+  const res = await policy.load(fixtures + '/project.snyk/project1');
+  const expected = {
+    version: 'v1.0.0',
+    ignore: {},
+    patch: {},
+    __filename: path.relative(
+      process.cwd(),
+      fixtures + '/project.snyk/project1/.snyk'
+    ),
+    __modified: res.__modified ? new Date(res.__modified) : false,
+    __created: res.__created ? new Date(res.__created) : false,
+  };
+
+  stripFunctions(res);
+
+  expect(res).toStrictEqual(expected);
+});
+
+test('policy.load (multiple - ignore first)', async () => {
+  const res = await policy.load([fixtures + '/ignore', fixtures + '/patch']);
+
+  const filename = path.relative(process.cwd(), fixtures + '/ignore/.snyk');
+  expect(res.__filename).toBe(filename);
+
+  const patchPkg = require(fixtures + '/patch/package.json');
+
+  const patchIds = Object.keys(res.patch);
+  const id = patchIds.shift();
+
+  const deepPatchPath = Object.keys(res.patch[id][0]).shift().split(' > ');
+
+  // FIXME is this right, should it include the version?
+  expect(deepPatchPath[0]).toBe(patchPkg.name + '@' + patchPkg.version);
+});
+
+test('policy.load (multiple - ignore last)', async () => {
+  const res = await policy.load([fixtures + '/patch', fixtures + '/ignore']);
+
+  const ids = [
+    'npm:hawk:20160119',
+    'npm:is-my-json-valid:20160118',
+    'npm:tar:20151103',
+    'npm:method-override:20170927',
+    'npm:marked:20170907',
+  ];
+
+  expect(res.ignore).toStrictEqual({});
+  expect(res.suggest).toBeTruthy();
+  expect(Object.keys(res.suggest)).toStrictEqual(ids);
+});
+
+test('policy.load (multiple - ignore last - trust deep policy)', async () => {
+  const res = await policy.load([fixtures + '/patch', fixtures + '/ignore'], {
+    'trust-policies': true,
   });
+
+  const ids = [
+    'npm:hawk:20160119',
+    'npm:is-my-json-valid:20160118',
+    'npm:tar:20151103',
+    'npm:method-override:20170927',
+    'npm:marked:20170907',
+  ];
+
+  expect(res.suggest).toBeFalsy();
+  expect(Object.keys(res.ignore)).not.toHaveLength(0);
+  expect(Object.keys(res.ignore)).toStrictEqual(ids);
 });
 
-test('policy.load (single .snyk in path name)', function (t) {
-  return policy.load(fixtures + '/project.snyk').then(function (res) {
-    const expect = {
-      version: 'v1.0.0',
-      ignore: {},
-      patch: {},
-      __filename: path.relative(
-        process.cwd(),
-        fixtures + '/project.snyk/.snyk'
-      ),
-      __modified: res.__modified ? new Date(res.__modified) : false,
-      __created: res.__created ? new Date(res.__created) : false,
-    };
-
-    stripFunctions(res);
-
-    t.same(res, expect, 'policy is as expected');
-  });
-});
-
-test('policy.load (double .snyk in path name)', function (t) {
-  return policy
-    .load(fixtures + '/project.snyk/project1.snyk')
-    .then(function (res) {
-      const expect = {
-        version: 'v1.0.0',
-        ignore: {},
-        patch: {},
-        __filename: path.relative(
-          process.cwd(),
-          fixtures + '/project.snyk/project1.snyk/.snyk'
-        ),
-        __modified: res.__modified ? new Date(res.__modified) : false,
-        __created: res.__created ? new Date(res.__created) : false,
-      };
-
-      stripFunctions(res);
-
-      t.same(res, expect, 'policy is as expected');
-    });
-});
-
-test('policy.load (single .snyk in path name but at upper level)', function (t) {
-  return policy.load(fixtures + '/project.snyk/project1').then(function (res) {
-    const expect = {
-      version: 'v1.0.0',
-      ignore: {},
-      patch: {},
-      __filename: path.relative(
-        process.cwd(),
-        fixtures + '/project.snyk/project1/.snyk'
-      ),
-      __modified: res.__modified ? new Date(res.__modified) : false,
-      __created: res.__created ? new Date(res.__created) : false,
-    };
-
-    stripFunctions(res);
-
-    t.same(res, expect, 'policy is as expected');
-  });
-});
-
-test('policy.load (multiple - ignore first)', function (t) {
-  return policy
-    .load([fixtures + '/ignore', fixtures + '/patch'])
-    .then(function (res: any) {
-      const filename = path.relative(process.cwd(), fixtures + '/ignore/.snyk');
-      t.equal(res.__filename, filename, 'first file is __filename');
-
-      const patchPkg = require(fixtures + '/patch/package.json');
-
-      const patchIds = Object.keys(res.patch);
-      const id = patchIds.shift();
-
-      const deepPatchPath = Object.keys(res.patch[id][0]).shift().split(' > ');
-
-      // FIXME is this right, should it include the version?
-      t.equal(
-        deepPatchPath[0],
-        patchPkg.name + '@' + patchPkg.version,
-        'first policy was prepended'
-      );
-    });
-});
-
-test('policy.load (multiple - ignore last)', function (t) {
-  return policy
-    .load([fixtures + '/patch', fixtures + '/ignore'])
-    .then(function (res) {
-      const ids = [
-        'npm:hawk:20160119',
-        'npm:is-my-json-valid:20160118',
-        'npm:tar:20151103',
-        'npm:method-override:20170927',
-        'npm:marked:20170907',
-      ];
-      t.same(res.ignore, {}, 'nothing is ignored');
-      t.ok(res.suggest, 'suggestions are present');
-      t.same(
-        Object.keys(res.suggest),
-        ids,
-        'suggestions are present and correct'
-      );
-    });
-});
-
-test('policy.load (multiple - ignore last - trust deep policy)', function (t) {
-  return policy
-    .load([fixtures + '/patch', fixtures + '/ignore'], {
-      'trust-policies': true,
-    })
-    .then(function (res) {
-      const ids = [
-        'npm:hawk:20160119',
-        'npm:is-my-json-valid:20160118',
-        'npm:tar:20151103',
-        'npm:method-override:20170927',
-        'npm:marked:20170907',
-      ];
-      t.notOk(res.suggest, 'no suggestions');
-      t.not(Object.keys(res.ignore).length, 0, 'has more than one ignore');
-      t.same(Object.keys(res.ignore), ids, 'inherited ignores are correct');
-    });
-});
-
-test('policy.load (merge)', function (t) {
+test('policy.load (merge)', async () => {
   const id = 'npm:uglify-js:20151024';
-  return policy
-    .load([fixtures + '/patch', fixtures + '/patch-mean'])
-    .then(function (res) {
-      t.equal(res.patch[id].length, 3, 'expect 2 from mean, 1 from patch');
+  const res = await policy.load([
+    fixtures + '/patch',
+    fixtures + '/patch-mean',
+  ]);
 
-      const formatted = policy.demunge(res);
+  expect(res.patch[id]).toHaveLength(3);
 
-      const single = formatted.patch
-        .filter(function (p) {
-          return p.id === id;
-        })
-        .shift();
+  const formatted = policy.demunge(res);
 
-      t.equal(single.paths.length, 3, 'still have 3 paths for single patch');
+  const single = formatted.patch.filter((p) => p.id === id).shift();
 
-      const filtered = single.paths.filter(function (item) {
-        return item.path.indexOf('mean') === 0;
-      });
+  expect(single.paths).toHaveLength(3);
 
-      t.equal(filtered.length, 2, 'two of which come from mean');
-    });
+  const filtered = single.paths.filter(
+    (item) => item.path.indexOf('mean') === 0
+  );
+
+  expect(filtered).toHaveLength(2);
 });
 
-test('policy.loadFromText', function (t) {
-  return fs
-    .readFile(fixtures + '/ignore/.snyk', 'utf8')
-    .then(policy.loadFromText)
-    .then(function (fromText) {
-      return policy.load(fixtures + '/ignore').then(function (fromDir) {
-        t.same(fromText.patch, fromDir.patch);
-        t.same(fromText.ignore, fromDir.ignore);
-        t.equal(fromText.version, fromDir.version);
-      });
-    });
+test('policy.loadFromText', async () => {
+  const file = await fs.readFile(fixtures + '/ignore/.snyk', 'utf8');
+  const fromText = await policy.loadFromText(file);
+
+  const fromDir = await policy.load(fixtures + '/ignore');
+
+  expect(fromText.patch).toStrictEqual(fromDir.patch);
+  expect(fromText.ignore).toStrictEqual(fromDir.ignore);
+  expect(fromText.version).toBe(fromDir.version);
 });
 
-test('policy.load (multiple - ENOENT - loose)', function (t) {
-  return policy
-    .load([fixtures + '/patch', fixtures + '/404'], { loose: true })
-    .then(function (res) {
-      const ids = [
-        'npm:uglify-js:20150824',
-        'npm:uglify-js:20151024',
-        'npm:semver:20150403',
-      ];
-      t.same(Object.keys(res.patch), ids, 'policy loaded');
-    });
+test('policy.load (multiple - ENOENT - loose)', async () => {
+  const res = await policy.load([fixtures + '/patch', fixtures + '/404'], {
+    loose: true,
+  });
+
+  const ids = [
+    'npm:uglify-js:20150824',
+    'npm:uglify-js:20151024',
+    'npm:semver:20150403',
+  ];
+
+  expect(Object.keys(res.patch)).toStrictEqual(ids);
 });
 
-test('policy.load (multiple - expect ENOENT)', function (t) {
-  return policy
-    .load([fixtures + '/patch', fixtures + '/404'], { loose: false })
-    .then(function () {
-      t.fail('missing policy should have thrown');
-    })
-    .catch(function (e) {
-      t.equal(e.code, 'ENOENT', 'errors correctly');
-    });
+test('policy.load (multiple - expect ENOENT)', () => {
+  expect(
+    policy
+      .load([fixtures + '/patch', fixtures + '/404'], { loose: false })
+      .catch((e) => {
+        expect(e.code).toBe('ENOENT');
+        throw e;
+      })
+  ).rejects.toThrow();
 });
 
 function stripFunctions(res) {
   // strip functions (as they don't land in the final config)
-  Object.keys(res).map(function (key) {
+  Object.keys(res).forEach((key) => {
     if (typeof res[key] === 'function') {
       delete res[key];
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    dir: 'test',
+    coverage: {
+      provider: 'c8',
+      reporter: ['text', 'html'],
+
+      branches: 85,
+      functions: 85,
+      lines: 85,
+      statements: 85,
+    },
+  },
+});


### PR DESCRIPTION
#### What does this PR do?

Switches from [TAP](https://node-tap.org/) to [vitest](https://vitest.dev/) and replaces [sinon](https://sinonjs.org/) for vitest mocking

TAP was simply way too slow clocking in at around 28 sec (see below), whereas vitest runs in just over 5 sec for the full suite. vitest also has much better editor integration (last image) with seamless debugging

Note: the way that tests are aggregated does differ, but all tests have been ported

#### How should this be manually tested?

`npm run test`

#### Screenshots

Old, slow test run with TAP 🐢 
<img width="893" alt="image" src="https://user-images.githubusercontent.com/918774/235705321-d0e9e925-98f7-4c09-97b5-2652dc35841f.png">

New, fast test run with vitest! 🚀 
<img width="960" alt="image" src="https://user-images.githubusercontent.com/918774/235704141-3b8ec9e5-9e3e-4f85-8e6a-306091464b00.png">

Editor integration
<img width="1813" alt="image" src="https://user-images.githubusercontent.com/918774/235704775-7112d611-13e1-499b-a8ee-b692d323a10b.png">