### PR TITLE
fix: default to an empty policy when an YAML array is passed in for the policy file

### DIFF
--- a/lib/parser/index.ts
+++ b/lib/parser/index.ts
@@ -15,9 +15,12 @@ const parsers = {
 };
 
 function imports(rawYaml = '') {
+  const isObject = (v: any) =>
+    Object.prototype.toString.call(v) === '[object Object]'; // typeof returns true for arrays and other types
+
   let data = yaml.safeLoad(rawYaml);
 
-  if (!data || typeof data !== 'object') {
+  if (!data || !isObject(data)) {
     data = {};
   }
 

--- a/test/unit/parser.test.ts
+++ b/test/unit/parser.test.ts
@@ -26,6 +26,20 @@ test('parser fills out defaults for invalid inputs', () => {
   expect(res).toStrictEqual(expected);
 });
 
+test('parser fills out defaults for invalid array input', () => {
+  const res = parser.import(
+    `# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.+
+    - object Object`
+  );
+  const expected = {
+    version: 'v1.0.0',
+    ignore: {},
+    patch: {},
+  };
+
+  expect(res).toStrictEqual(expected);
+});
+
 test('parser does not modify default parsed format', () => {
   const expected = {
     version: 'v1.0.0',


### PR DESCRIPTION
#### What does this PR do?

Defaults to an empty policy file when an array is passed in.

Currently, we have a customer passing in a YAML array (below) as a policy file and the policy library is not handling it gracefully
```
# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
    - object Object
 ```

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/NARW-2055
