### PR TITLE
fix: save policies with the latest schema version

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,6 +13,9 @@ export { filter, load, save, loadFromText, add, addExclude, create };
 
 const debug = newDebug('snyk:policy');
 
+/** Returns the version of the latest policy schema */
+export const latestVersion = () => 'v1.25.1'; // only major _should_ matter, but deferring for now
+
 function create() {
   return loadFromText('');
 }

--- a/lib/parser/index.ts
+++ b/lib/parser/index.ts
@@ -1,6 +1,7 @@
 import * as yaml from 'js-yaml';
 import cloneDeep from 'lodash.clonedeep';
 import * as semver from 'semver';
+import { latestVersion } from '../';
 import { version as versionFromPackageJson } from '../../package.json';
 import addComments from './add-comments';
 import v1 from './v1';
@@ -8,6 +9,7 @@ import v1 from './v1';
 export { default as demunge } from './demunge';
 export { imports as import, exportsFn as export, packageVersion as version };
 
+const defaultPolicyVersion = 'v1';
 const packageVersion = version();
 
 const parsers = {
@@ -25,7 +27,7 @@ function imports(rawYaml = '') {
   }
 
   if (!data.version) {
-    data.version = 'v1';
+    data.version = defaultPolicyVersion;
   }
 
   if (data.version === 'v1') {
@@ -63,11 +65,14 @@ function exportsFn(policy) {
   });
 
   // ensure we always update the version of the policy format
-  data.version = version();
+  data.version = latestVersion();
   // put inline comments into the exported yaml file
   return addComments(yaml.safeDump(data));
 }
 
+/**
+ * @deprecated
+ */
 function version() {
   if (versionFromPackageJson && versionFromPackageJson !== '0.0.0') {
     return 'v' + versionFromPackageJson;

--- a/test/unit/policy-save.test.ts
+++ b/test/unit/policy-save.test.ts
@@ -10,7 +10,10 @@ afterEach(() => {
 });
 
 test('policy.save', async () => {
+  const mockLatestVersion = 'v1.2.3';
+
   const writeFileStub = vi.spyOn(fs, 'writeFile').mockResolvedValueOnce();
+  vi.spyOn(policy, 'latestVersion').mockReturnValue(mockLatestVersion);
 
   const filename = path.resolve(fixtures + '/ignore/.snyk');
   let asText = '';
@@ -24,6 +27,10 @@ test('policy.save', async () => {
 
   expect(writeFileStub).toHaveBeenCalledOnce();
   expect(writeFileStub).toHaveBeenCalledWith(filename, expect.anything());
+
+  // always save with the latest schema version
+  asText = asText.replace('version: v1.0.0', 'version: ' + mockLatestVersion);
+
   const parsed = (writeFileStub.mock.calls[0][1] as string).trim();
   expect(parsed).toBe(asText);
   expect(parsed).toMatch(


### PR DESCRIPTION
#### What does this PR do?

Saves policies with the latest schema version.

The policy schema version was coupled to the library version. When we bumped the library to v2 for a potentially breaking change to the library (but no changes to the schema), the library started looking for a non-existent v2 parser.

In #106 we decoupled the default schema version from the library version for reading policies, but files were still be written with the library's latest version. Which again, resulting in the library looking for a v2 parser

This was caught during the [integration tests in Registry](https://app.circleci.com/pipelines/github/snyk/registry/240428/workflows/b5a96f96-03e7-4955-b367-68bc7418d22c/jobs/1134697)

#### How should this be manually tested?

- Load a policy with any verion
- Save the policy (should be saved with latest schema version)
- Then try to reload the policy
