### PR TITLE
chore: update CircleCI context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,10 +167,8 @@ workflows:
     jobs:
       - install:
           name: Install
-          context: nodejs-lib-release
       - lint:
           name: Lint
-          context: nodejs-lib-release
           requires:
             - Install
           filters:
@@ -179,7 +177,6 @@ workflows:
                 - master
       - test:
           name: Test
-          context: nodejs-lib-release
           requires:
             - Lint
           matrix:
@@ -196,14 +193,13 @@ workflows:
 
       - scan:
           name: Snyk Vuln Scan
-          context: 
-            - nodejs-lib-release
+          context: narwhal-policy
           requires:
             - Install
 
       - release:
           name: Release
-          context: nodejs-lib-release
+          context: narwhal-policy
           filters:
             branches:
               only:
@@ -213,11 +209,9 @@ workflows:
     jobs:
       - install:
           name: Install
-          context: nodejs-lib-release
       - scan:
           name: Snyk Vuln Scan
-          context: 
-            - nodejs-lib-release
+          context: narwhal-policy
           requires:
             - Install
     triggers:


### PR DESCRIPTION
#### What does this PR do?

The `snyksec` Github service account [is being disabled](https://snyk.slack.com/archives/C017V2JPKNX/p1683551183603779) to comply with the [ProdSec security standards](https://potential-adventure-z7gm728.pages.github.io/standards/standard_for_circleci_secrets_usage.html), so each team must create their own Github service account. The Narwhal service account can be found in the `Team Narwhal` 1Password vault.

Further, as per the standards, secrets and contexts should not be shared across projects where possible to limit the blast radius. So, as part of this work, a `narwhal-policy` CircleCI context has been created with a project specific `SNYK_TOKEN` and `GITHUB_PRIVATE_TOKEN`. This PR updates the context, after which, the `SNYK_TOKEN` environment variable will be removed from CircleCI