### PR TITLE
chore: type index

### DIFF
--- a/lib/add-exclude.ts
+++ b/lib/add-exclude.ts
@@ -1,13 +1,29 @@
+import { ExcludeRuleSet, PatternGroup, Policy, Rule } from './types';
+
 export default addExclude;
 
-function addExclude(policy, pattern, group = 'global', options: any = {}) {
+type AddExcludeOptions = Rule;
+
+/**
+ * Adds an exclude rule to the policy.
+ * @param policy (*mutates!*) the policy object to add the rule to
+ * @param pattern the pattern to exclude
+ * @param group the pattern group to add the pattern to
+ * @param options the options for the rule
+ */
+function addExclude(
+  policy: Policy,
+  pattern: string,
+  group: PatternGroup = 'global',
+  options = {} as AddExcludeOptions
+) {
   if (!isPatternGroupValid(group)) {
     throw new Error('invalid file pattern-group');
   }
 
-  policy.exclude = policy.exclude || {};
+  policy.exclude = policy.exclude ?? ({} as ExcludeRuleSet);
 
-  let patterns = policy.exclude[group] || [];
+  let patterns = policy.exclude[group] ?? [];
 
   // Remove duplicates
   patterns = patterns.filter((p) => p !== pattern && !p[pattern]);
@@ -20,6 +36,6 @@ function addExclude(policy, pattern, group = 'global', options: any = {}) {
   policy.exclude[group] = [...patterns, entry];
 }
 
-function isPatternGroupValid(group) {
+function isPatternGroupValid(group: string) {
   return ['global', 'code', 'iac-drift'].includes(group);
 }

--- a/lib/add.ts
+++ b/lib/add.ts
@@ -3,10 +3,27 @@ export default add;
 import newDebug from 'debug';
 import * as emailValidator from 'email-validator';
 
-const debug = newDebug('snyk:policy');
-const validReasonTypes = ['not-vulnerable', 'wont-fix', 'temporary-ignore'];
+import { AddRuleOptions, PathObj, Policy, ReasonType, Rule } from './types';
 
-function add(policy, type, options) {
+const debug = newDebug('snyk:policy');
+const validReasonTypes: ReasonType[] = [
+  'not-vulnerable',
+  'wont-fix',
+  'temporary-ignore',
+];
+
+/**
+ * Adds an ignore or patch rule to the policy.
+ * @param policy (*mutates!*) the policy object to add the rule to
+ * @param type the type of rule to add
+ * @param options the options for the rule
+ * @returns the policy object
+ */
+function add(
+  policy: Policy,
+  type: 'ignore' | 'patch',
+  options: AddRuleOptions
+) {
   if (type !== 'ignore' && type !== 'patch') {
     throw new Error('policy.add: unknown type "' + type + '" to add to');
   }
@@ -17,42 +34,42 @@ function add(policy, type, options) {
 
   const id = options.id;
   const path = options.path;
-  const data = Object.keys(options).reduce(function (acc, curr) {
+  const data = Object.keys(options).reduce((acc, curr) => {
     if (curr === 'id' || curr === 'path') {
       return acc;
     }
 
     if (
       curr === 'reasonType' &&
-      validReasonTypes.indexOf(options[curr]) === -1
+      options.reasonType &&
+      validReasonTypes.indexOf(options.reasonType) === -1
     ) {
       throw new Error('invalid reasonType ' + options[curr]);
     }
 
-    if (curr === 'ignoredBy') {
-      if (typeof options[curr] !== 'object') {
+    if (curr === 'ignoredBy' && options.ignoredBy) {
+      if (typeof options.ignoredBy !== 'object') {
         throw new Error('ignoredBy must be an object');
       }
 
-      if (!emailValidator.validate(options[curr].email)) {
+      if (!emailValidator.validate(options.ignoredBy.email)) {
         throw new Error('ignoredBy.email must be a valid email address');
       }
     }
 
     acc[curr] = options[curr];
     return acc;
-  }, {});
+  }, {} as Rule);
 
   if (!policy[type][id]) {
     policy[type][id] = [];
   }
 
-  /* istanbul ignore if */
   if (policy[type][id][path]) {
     debug('policy.add: path already exists', policy[type][id][path]);
   }
 
-  const rule = {};
+  const rule = {} as PathObj;
   rule[path] = data;
 
   policy[type][id].push(rule);

--- a/lib/filter/ignore.ts
+++ b/lib/filter/ignore.ts
@@ -4,8 +4,14 @@ import newDebug from 'debug';
 import cloneDeep from 'lodash.clonedeep';
 
 import { matchToRule } from '../match';
-import { MatchStrategy, PathObj, RuleSet, Vulnerability } from '../types';
-import { FilteredRule, FilteredVulnerability } from '.';
+import {
+  FilteredRule,
+  FilteredVulnerability,
+  MatchStrategy,
+  PathObj,
+  RuleSet,
+  Vulnerability,
+} from '../types';
 
 const debug = newDebug('snyk:policy');
 

--- a/lib/filter/index.ts
+++ b/lib/filter/index.ts
@@ -3,10 +3,10 @@ export default filter;
 import newDebug from 'debug';
 
 import {
+  FilteredVulnerability,
+  FilteredVulns,
   MatchStrategy,
   Policy,
-  Rule,
-  Vulnerability,
   VulnsObject,
 } from '../types';
 import ignore from './ignore';
@@ -14,29 +14,6 @@ import notes from './notes';
 import patch from './patch';
 
 const debug = newDebug('snyk:policy');
-
-export interface FilteredRule extends Rule {
-  path: string[];
-}
-
-export interface FilteredVulnerability extends Vulnerability {
-  filtered?: {
-    ignored?: FilteredRule[];
-    patches?: FilteredRule[];
-  };
-  note?: string;
-}
-
-export interface FilteredVulns {
-  ok: boolean;
-
-  vulnerabilities: FilteredVulnerability[];
-
-  filtered?: {
-    ignore: Vulnerability[];
-    patch: Vulnerability[];
-  };
-}
 
 /**
  * Applies the specified policy to the vulnerabilities object.
@@ -49,7 +26,7 @@ export interface FilteredVulns {
 function filter(
   vulns: VulnsObject,
   policy: Policy,
-  root: string,
+  root?: string,
   matchStrategy: MatchStrategy = 'packageManager'
 ) {
   if (!root) {

--- a/lib/filter/notes.ts
+++ b/lib/filter/notes.ts
@@ -3,8 +3,7 @@ export default attachNotes;
 import newDebug from 'debug';
 
 import { matchToRule } from '../match';
-import { RuleSet, Vulnerability } from '../types';
-import { FilteredVulnerability } from '.';
+import { FilteredVulnerability, RuleSet, Vulnerability } from '../types';
 
 const debug = newDebug('snyk:policy');
 
@@ -64,7 +63,7 @@ function attachNotes(notes: RuleSet, vuln: Vulnerability[]) {
 
           if (pathMatch) {
             // strip any control characters in the 3rd party reason file
-            const reason = rule[path].reason.replace(
+            const reason = rule[path].reason?.replace(
               '/[\x00-\x1F\x7F-\x9F]/u',
               ''
             );

--- a/lib/filter/patch.ts
+++ b/lib/filter/patch.ts
@@ -6,9 +6,13 @@ import cloneDeep from 'lodash.clonedeep';
 import * as path from 'path';
 
 import { matchToRule } from '../match';
-import { RuleSet, Vulnerability } from '../types';
+import {
+  FilteredRule,
+  FilteredVulnerability,
+  RuleSet,
+  Vulnerability,
+} from '../types';
 import getVulnSource from './get-vuln-source';
-import { FilteredRule, FilteredVulnerability } from '.';
 
 const debug = newDebug('snyk:policy');
 

--- a/lib/match.ts
+++ b/lib/match.ts
@@ -202,12 +202,12 @@ function getByVuln(policy?: Policy, vuln?: Vulnerability): VulnRule | null {
     return found;
   }
 
-  (['ignore', 'patch'] as ('ignore' | 'patch')[]).forEach((key) => {
+  for (const key of ['ignore', 'patch'] as ('ignore' | 'patch')[]) {
     Object.keys(policy[key] || []).forEach((p) => {
       if (p === vuln.id) {
-        policy[key][p].forEach((rule) => {
+        for (const rule of policy[key][p]) {
           if (matchToRule(vuln, rule)) {
-            const rootRule = Object.keys(rule).pop()!;
+            const rootRule = Object.keys(rule).pop()!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
             found = {
               type: key,
               id: vuln.id,
@@ -215,10 +215,10 @@ function getByVuln(policy?: Policy, vuln?: Vulnerability): VulnRule | null {
               ...rule[rootRule],
             } as VulnRule;
           }
-        });
+        }
       }
     });
-  });
+  }
 
   return found;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,41 @@
+export interface AddRuleOptions extends Rule {
+  /**
+   * The id of the vulnerability to which the rule applies.
+   */
+  id: string;
+
+  /**
+   * The path or the dependency to which the rule applies.
+   */
+  path: string;
+
+  reasonType?: ReasonType;
+}
+
 export type ExcludeRuleSet = Record<PatternGroup, (string | PathObj)[]>;
+
+export interface FilteredRule extends Rule {
+  path: string[];
+}
+
+export interface FilteredVulnerability extends Vulnerability {
+  filtered?: {
+    ignored?: FilteredRule[];
+    patches?: FilteredRule[];
+  };
+  note?: string;
+}
+
+export interface FilteredVulns {
+  ok: boolean;
+
+  vulnerabilities: FilteredVulnerability[];
+
+  filtered?: {
+    ignore: Vulnerability[];
+    patch: Vulnerability[];
+  };
+}
 
 export type MatchStrategy = 'packageManager' | 'exact';
 
@@ -12,6 +49,28 @@ export interface MetaRule extends Rule {
 export interface Package {
   name: string;
   version: string;
+}
+
+/**
+ * @example
+ * {
+ *  "urls": [
+ *    "https://raw.githubusercontent.com/Snyk/vulndb/snapshots/master/patches/npm/handlebars/20151207/handlebars_0.patch"
+ *  ],
+ *  "version": "<4.0.0 >=3.0.2",
+ *  "modificationTime": "2015-12-14T23:52:16.811Z",
+ *  "comments": [
+ *    "https://github.com/wycats/handlebars.js/commit/83b8e846a3569bd366cf0b6bdc1e4604d1a2077e"
+ *  ],
+ *  "id": "patch:npm:handlebars:20151207:0"
+ * }
+ */
+interface Patch {
+  urls: string[];
+  version: string;
+  modificationTime: string;
+  comments: string[];
+  id: string;
 }
 
 /**
@@ -40,6 +99,16 @@ export interface Policy {
   failThreshold: Severity;
   skipVerifyPatch: boolean;
   version: string;
+
+  add: (type: 'ignore' | 'patch', options: AddRuleOptions) => Policy;
+  addExclude: (pattern: string, group?: PatternGroup, options?: Rule) => void;
+  addIgnore: (options: AddRuleOptions) => Policy;
+  addPatch: (options: AddRuleOptions) => Policy;
+  filter: (
+    vulns: VulnsObject,
+    root?: string,
+    matchStrategy?: MatchStrategy
+  ) => FilteredVulns;
 }
 
 export class PolicyError extends Error {
@@ -52,6 +121,8 @@ export class PolicyError extends Error {
   }
 }
 
+export type ReasonType = 'not-vulnerable' | 'wont-fix' | 'temporary-ignore';
+
 /**
  * @example
  * {
@@ -60,15 +131,15 @@ export class PolicyError extends Error {
  * }
  */
 export interface Rule {
-  created: Date;
-  disregardIfFixable: boolean;
+  created?: Date;
+  disregardIfFixable?: boolean;
   expires?: string | Date;
-  ignoredBy: {
+  ignoredBy?: {
     email: string;
   };
-  reason: string;
-  reasonType: string;
-  source: string;
+  reason?: string;
+  reasonType?: ReasonType;
+  source?: string;
   from?: string;
   patched?: string;
 }
@@ -117,10 +188,10 @@ export interface Vulnerability {
   from: string[];
 
   isUpgradable: boolean;
-  upgradePath: any[];
+  upgradePath: (string | false)[];
 
   isPatchable: boolean;
-  patches: any[];
+  patches: Patch[];
 
   securityPolicyMetaData: SecurityPolicyMetaData;
 }
@@ -146,7 +217,7 @@ export interface VulnsObject {
   /**
    * If all the vulns are stripped because of the policy, then the `ok` bool is set to `true`.
    */
-  ok: boolean;
+  ok?: boolean;
 
   /**
    * The vulnerabilities found in the project.
@@ -163,4 +234,12 @@ export interface VulnsObject {
  */
 export function isObject(v: unknown): v is Record<string, unknown> {
   return Object.prototype.toString.call(v) === '[object Object]';
+}
+
+/**
+ * Returns true if the error is a NodeJS error.
+ * @param value The value to check.
+ */
+export function isNodeError(value: unknown): value is NodeJS.ErrnoException {
+  return value instanceof Error;
 }

--- a/test/functional/SC-1026.test.ts
+++ b/test/functional/SC-1026.test.ts
@@ -12,6 +12,13 @@ test('filtered vulns can still be reviewed', async () => {
   const res = p.filter(vulns);
 
   expect(res.ok).toBe(false);
+
+  expect(res.filtered).toBeDefined();
+  expect(res.filtered).toBeInstanceOf(Object);
+  if (res.filtered === undefined) {
+    return;
+  }
+
   expect(res.filtered.ignore).toBeInstanceOf(Array);
   expect(res.filtered.ignore).length.greaterThan(0);
   expect(res.filtered.patch).toBeInstanceOf(Array);

--- a/test/unit/add-exclude.test.ts
+++ b/test/unit/add-exclude.test.ts
@@ -1,12 +1,13 @@
 import { expect, test } from 'vitest';
 import { create } from '../../lib';
+import { PatternGroup } from 'lib/types';
 
 test('use of invalid file pattern-group throws errors', async () => {
   let policy = await create();
 
   expect(() => {
     const invalidGroup = 'unmanaged';
-    policy.addExclude('./deps/*.ts', invalidGroup);
+    policy.addExclude('./deps/*.ts', invalidGroup as PatternGroup);
   }).toThrow('invalid file pattern-group');
 });
 
@@ -21,7 +22,7 @@ test('add a new file pattern to default group', async (t) => {
   }).does.not.toThrow();
 });
 
-test('add a new file pattern to global-group', async (t) => {
+test('add a new file pattern to global-group', async (_t) => {
   let policy = await create();
 
   expect(() => {
@@ -33,7 +34,7 @@ test('add a new file pattern to global-group', async (t) => {
   }).does.not.toThrow();
 });
 
-test('add a new file pattern to code-group', async (t) => {
+test('add a new file pattern to code-group', async (_t) => {
   let policy = await create();
   expect(() => {
     const validGroup = 'code';
@@ -44,7 +45,7 @@ test('add a new file pattern to code-group', async (t) => {
   }).does.not.toThrow();
 });
 
-test('add a new file pattern to iac drift-group', async (t) => {
+test('add a new file pattern to iac drift-group', async (_t) => {
   let policy = await create();
   expect(() => {
     const validGroup = 'iac-drift';
@@ -60,7 +61,7 @@ test('add a new file pattern to iac drift-group', async (t) => {
   }).does.not.toThrow();
 });
 
-test('add two new unique file pattern to a group', async (t) => {
+test('add two new unique file pattern to a group', async (_t) => {
   let policy = await create();
   expect(() => {
     policy.addExclude('./deps/*.ts');
@@ -71,7 +72,7 @@ test('add two new unique file pattern to a group', async (t) => {
   }).does.not.toThrow();
 });
 
-test('replace duplicates patterns', async (t) => {
+test('replace duplicates patterns', async (_t) => {
   let policy = await create();
 
   expect(() => {
@@ -94,17 +95,17 @@ test('add dates and reasons', async (t) => {
       reason: 'incidents already fixed by user',
     });
 
-    expect(policy.exclude['global'][0]['./deps/*.ts'].expires).toBe(
+    expect(policy.exclude?.['global'][0]['./deps/*.ts'].expires).toBe(
       '2092-12-24'
     );
 
-    expect(policy.exclude['global'][0]['./deps/*.ts'].reason).toBe(
+    expect(policy.exclude?.['global'][0]['./deps/*.ts'].reason).toBe(
       'incidents already fixed by user'
     );
   }).does.not.toThrow();
 });
 
-test('replace existing objects', async (t) => {
+test('replace existing objects', async (_t) => {
   let policy = await create();
   expect(() => {
     policy.addExclude('./deps/*.ts', 'global', {
@@ -117,17 +118,17 @@ test('replace existing objects', async (t) => {
       reason: 'it will never happen',
     });
 
-    expect(policy.exclude['global'][0]['./deps/*.ts'].expires).toBe(
+    expect(policy.exclude?.['global'][0]['./deps/*.ts'].expires).toBe(
       '2192-12-24'
     );
 
-    expect(policy.exclude['global'][0]['./deps/*.ts'].reason).toBe(
+    expect(policy.exclude?.['global'][0]['./deps/*.ts'].reason).toBe(
       'it will never happen'
     );
   }).does.not.toThrow();
 });
 
-test('only replace duplicates', async (t) => {
+test('only replace duplicates', async (_t) => {
   let policy = await create();
   expect(() => {
     policy.addExclude('./deps/*.ts', 'global', {
@@ -142,13 +143,13 @@ test('only replace duplicates', async (t) => {
       reason: 'it will never happen',
     });
 
-    expect(policy.exclude['global'][0]).toBe('./vendor/*.go');
+    expect(policy.exclude?.['global'][0]).toBe('./vendor/*.go');
 
-    expect(policy.exclude['global'][1]['./deps/*.ts'].expires).toBe(
+    expect(policy.exclude?.['global'][1]['./deps/*.ts'].expires).toBe(
       '2192-12-24'
     );
 
-    expect(policy.exclude['global'][1]['./deps/*.ts'].reason).toBe(
+    expect(policy.exclude?.['global'][1]['./deps/*.ts'].reason).toBe(
       'it will never happen'
     );
   }).does.not.toThrow();

--- a/test/unit/add.test.ts
+++ b/test/unit/add.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest';
 import { create } from '../../lib';
+import { ReasonType } from 'lib/types';
 
 test('add errors without options', async () => {
   let policy = await create();
@@ -53,17 +54,12 @@ test('add ignore with invalid reasonType', async () => {
   let policy = await create();
 
   expect(() =>
-    policy
-      .addIgnore({
-        id: 'a',
-        path: 'a > b',
-        reasonType: 'test',
-      })
-      .catch((err) => {
-        expect(err.message).toBe('invalid reasonType test');
-        throw err;
-      })
-  ).toThrow();
+    policy.addIgnore({
+      id: 'a',
+      path: 'a > b',
+      reasonType: 'test' as ReasonType,
+    })
+  ).toThrow('invalid reasonType test');
 });
 
 test('add ignore with valid ignoredBy', async () => {

--- a/test/unit/filter-ignore.test.ts
+++ b/test/unit/filter-ignore.test.ts
@@ -1,7 +1,9 @@
 import cloneDeep from 'lodash.clonedeep';
 import { expect, test } from 'vitest';
+
 import * as policy from '../../lib';
 import ignore from '../../lib/filter/ignore';
+import { Vulnerability } from '../types';
 
 const fixtures = __dirname + '/../fixtures/ignore';
 const vulns = require(fixtures + '/vulns.json');
@@ -225,7 +227,7 @@ test('filters vulnerabilities by exact match', async () => {
         id: 'another-vuln',
         from: ['file.json', 'foo', 'bar'],
       },
-    ],
+    ] as Vulnerability[],
   };
 
   const expected = cloneDeep(vulns);

--- a/test/unit/get-by-vuln.test.ts
+++ b/test/unit/get-by-vuln.test.ts
@@ -1,6 +1,8 @@
 import { promises as fs } from 'fs';
 import { expect, test } from 'vitest';
 import { getByVuln, loadFromText } from '../../lib';
+import { expectTypeOf } from 'vitest';
+import { VulnRule } from 'lib/types';
 
 const fixtures = __dirname + '/../fixtures';
 const policy = require(fixtures + '/ignore/parsed.json');
@@ -36,8 +38,12 @@ test('getByVuln with star rules', async () => {
   const policy = await loadFromText(file);
   const res = getByVuln(policy, vuln);
 
-  expect(res.id).toBe(id);
-  expect(res.rule).not.empty;
+  expect(res).not.toBeNull();
+
+  if (res !== null) {
+    expect(res.id).toBe(id);
+    expect(res.rule).not.empty;
+  }
 });
 
 test('getByVuln with exact match rules', async () => {
@@ -48,6 +54,10 @@ test('getByVuln with exact match rules', async () => {
   const policy = await loadFromText(file);
   const res = getByVuln(policy, vuln);
 
-  expect(res.id).toBe(id);
-  expect(res.rule).not.empty;
+  expect(res).not.toBeNull();
+
+  if (res !== null) {
+    expect(res.id).toBe(id);
+    expect(res.rule).not.empty;
+  }
 });

--- a/test/unit/policy.test.ts
+++ b/test/unit/policy.test.ts
@@ -92,7 +92,12 @@ test('policy.load (multiple - ignore first)', async () => {
   const patchIds = Object.keys(res.patch);
   const id = patchIds.shift();
 
-  const deepPatchPath = Object.keys(res.patch[id][0]).shift().split(' > ');
+  expect(id).toBeDefined();
+  if (id === undefined) {
+    return;
+  }
+
+  const deepPatchPath = Object.keys(res.patch[id][0]).shift()!.split(' > ');
 
   // FIXME is this right, should it include the version?
   expect(deepPatchPath[0]).toBe(patchPkg.name + '@' + patchPkg.version);
@@ -143,15 +148,19 @@ test('policy.load (merge)', async () => {
 
   const formatted = policy.demunge(res);
 
-  const single = formatted.patch.filter((p) => p.id === id).shift();
+  const single = formatted.patch.filter((p) => p.id === id).shift()!;
 
-  expect(single.paths).toHaveLength(3);
+  expect(single).toBeDefined();
 
-  const filtered = single.paths.filter(
-    (item) => item.path.indexOf('mean') === 0
-  );
+  if (single !== undefined) {
+    expect(single.paths).toHaveLength(3);
 
-  expect(filtered).toHaveLength(2);
+    const filtered = single.paths.filter(
+      (item) => item.path.indexOf('mean') === 0
+    );
+
+    expect(filtered).toHaveLength(2);
+  }
 });
 
 test('policy.loadFromText', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -82,9 +82,9 @@
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
 
     /* Type Checking */
-    "strict": false,                                     /* Enable all strict type-checking options. */
+    "strict": true,                                      /* Enable all strict type-checking options. */
     "noImplicitAny": false,                              /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    "strictNullChecks": false,                           /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */


### PR DESCRIPTION
#### What does this PR do?

This PR turns strict type-checking on (although implicit `any` is still currently allowed) and extends typing to cover the main package. This PR should not change any logic

#### What are the relevant tickets?

[NARW-2131](https://snyksec.atlassian.net/browse/NARW-2131)


[NARW-2131]: https://snyksec.atlassian.net/browse/NARW-2131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ