### PR TITLE
chore: type library dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.4",
+    "typescript": "~5.0.4",
     "vitest": "^0.30.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@commitlint/cli": "^17.6.1",
+    "@types/debug": "^4.1.8",
+    "@types/js-yaml": "^4.0.5",
+    "@types/lodash.clonedeep": "^4.5.7",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^5.59.1",
     "@vitest/coverage-c8": "^0.30.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,10 +31,10 @@
     "baseUrl": "./",                                     /* Specify the base directory to resolve non-relative module names. */
     "paths": {},                                         /* Specify a set of entries that re-map imports to additional lookup locations. */
     "rootDirs": ["./lib", "./test"],                     /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    "typeRoots": ["./types", "./node_modules/@types"],   /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "moduleSuffixes": [],                              /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
     // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
@@ -104,6 +104,6 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    // "skipLibCheck": true                              /* Skip type checking all .d.ts files. */
   }
 }

--- a/types/snyk-resolve.d.ts
+++ b/types/snyk-resolve.d.ts
@@ -1,0 +1,3 @@
+declare module 'snyk-resolve' {
+  export function sync(name?: string, basedir?: string): string;
+}

--- a/types/snyk-try-require.d.ts
+++ b/types/snyk-try-require.d.ts
@@ -1,0 +1,7 @@
+declare module 'snyk-try-require' {
+  export interface Package {
+    name: string;
+    version: string;
+  }
+  export default function tryRequire(name: string): Promise<Package>;
+}


### PR DESCRIPTION
#### What does this PR do?

Types the following dependencies either by installing the type if available or creating a custom type declaration file
- [debug](https://github.com/debug-js/debug)
- [js-yaml](https://github.com/nodeca/js-yaml)
- [lodash.clonedeep](https://github.com/lodash/lodash)
- [snyk-resolve](https://github.com/snyk/resolve-package)
- [snyk-try-require](https://github.com/Snyk/try-require)

Note: this also limits the version range of typescript to only minor updates and the latest `5.1.x` versions are causing OOM errors when linting. More info [here](https://github.com/microsoft/TypeScript/issues/53087)
