### PR TITLE
chore: turn strict type checking on

### DIFF
--- a/test/functional/SC-1026.test.ts
+++ b/test/functional/SC-1026.test.ts
@@ -1,9 +1,11 @@
 import { expect, test } from 'vitest';
+
 import * as policy from '../../lib';
+import { VulnerabilityReport } from '../types';
 
 const fixtures = __dirname + '/../fixtures';
 const dir = fixtures + '/filter-and-track';
-const vulns = require(dir + '/vulns.json');
+const vulns = require(dir + '/vulns.json') as VulnerabilityReport;
 
 test('filtered vulns can still be reviewed', async () => {
   const p = await policy.load(dir, { loose: true });
@@ -12,6 +14,13 @@ test('filtered vulns can still be reviewed', async () => {
   const res = p.filter(vulns);
 
   expect(res.ok).toBe(false);
+
+  expect(res.filtered).toBeDefined();
+  expect(res.filtered).toBeInstanceOf(Object);
+  if (res.filtered === undefined) {
+    return;
+  }
+
   expect(res.filtered.ignore).toBeInstanceOf(Array);
   expect(res.filtered.ignore).length.greaterThan(0);
   expect(res.filtered.patch).toBeInstanceOf(Array);

--- a/test/functional/severity-control.test.ts
+++ b/test/functional/severity-control.test.ts
@@ -1,10 +1,12 @@
 import fs from 'fs';
 import { beforeEach, expect, test } from 'vitest';
+
 import * as policy from '../../lib';
+import { VulnerabilityReport } from '../types';
 
 const fixtures = __dirname + '/../fixtures';
 const dir = fixtures + '/severity-control';
-let vulns: any = {};
+let vulns = {} as VulnerabilityReport;
 
 beforeEach(() => {
   // only contains medium + low - this file is read using fs to ensure refresh

--- a/test/unit/add-exclude.test.ts
+++ b/test/unit/add-exclude.test.ts
@@ -23,7 +23,7 @@ test('add a new file pattern to default group', async (t) => {
   }).does.not.toThrow();
 });
 
-test('add a new file pattern to global-group', async (t) => {
+test('add a new file pattern to global-group', async (_t) => {
   let policy = await create();
 
   expect(() => {
@@ -35,7 +35,7 @@ test('add a new file pattern to global-group', async (t) => {
   }).does.not.toThrow();
 });
 
-test('add a new file pattern to code-group', async (t) => {
+test('add a new file pattern to code-group', async (_t) => {
   let policy = await create();
   expect(() => {
     const validGroup = 'code';
@@ -46,7 +46,7 @@ test('add a new file pattern to code-group', async (t) => {
   }).does.not.toThrow();
 });
 
-test('add a new file pattern to iac drift-group', async (t) => {
+test('add a new file pattern to iac drift-group', async (_t) => {
   let policy = await create();
   expect(() => {
     const validGroup = 'iac-drift';
@@ -62,7 +62,7 @@ test('add a new file pattern to iac drift-group', async (t) => {
   }).does.not.toThrow();
 });
 
-test('add two new unique file pattern to a group', async (t) => {
+test('add two new unique file pattern to a group', async (_t) => {
   let policy = await create();
   expect(() => {
     policy.addExclude('./deps/*.ts');
@@ -73,7 +73,7 @@ test('add two new unique file pattern to a group', async (t) => {
   }).does.not.toThrow();
 });
 
-test('replace duplicates patterns', async (t) => {
+test('replace duplicates patterns', async (_t) => {
   let policy = await create();
 
   expect(() => {
@@ -96,17 +96,20 @@ test('add dates and reasons', async (t) => {
       reason: 'incidents already fixed by user',
     });
 
-    expect(policy.exclude['global'][0]['./deps/*.ts'].expires).toBe(
-      '2092-12-24'
-    );
+    const exclude1 = policy.exclude?.['global'][0];
+    expect(exclude1).toBeDefined();
+    expect(exclude1).not.toBeTypeOf('string');
 
-    expect(policy.exclude['global'][0]['./deps/*.ts'].reason).toBe(
-      'incidents already fixed by user'
-    );
+    if (exclude1 && typeof exclude1 !== 'string') {
+      expect(exclude1['./deps/*.ts'].expires).toBe('2092-12-24');
+      expect(exclude1['./deps/*.ts'].reason).toBe(
+        'incidents already fixed by user'
+      );
+    }
   }).does.not.toThrow();
 });
 
-test('replace existing objects', async (t) => {
+test('replace existing objects', async (_t) => {
   let policy = await create();
   expect(() => {
     policy.addExclude('./deps/*.ts', 'global', {
@@ -119,17 +122,18 @@ test('replace existing objects', async (t) => {
       reason: 'it will never happen',
     });
 
-    expect(policy.exclude['global'][0]['./deps/*.ts'].expires).toBe(
-      '2192-12-24'
-    );
+    const exclude1 = policy.exclude?.['global'][0];
+    expect(exclude1).toBeDefined();
+    expect(exclude1).not.toBeTypeOf('string');
 
-    expect(policy.exclude['global'][0]['./deps/*.ts'].reason).toBe(
-      'it will never happen'
-    );
+    if (exclude1 && typeof exclude1 !== 'string') {
+      expect(exclude1['./deps/*.ts'].expires).toBe('2192-12-24');
+      expect(exclude1['./deps/*.ts'].reason).toBe('it will never happen');
+    }
   }).does.not.toThrow();
 });
 
-test('only replace duplicates', async (t) => {
+test('only replace duplicates', async (_t) => {
   let policy = await create();
   expect(() => {
     policy.addExclude('./deps/*.ts', 'global', {
@@ -144,14 +148,15 @@ test('only replace duplicates', async (t) => {
       reason: 'it will never happen',
     });
 
-    expect(policy.exclude['global'][0]).toBe('./vendor/*.go');
+    expect(policy.exclude?.['global'][0]).toBe('./vendor/*.go');
 
-    expect(policy.exclude['global'][1]['./deps/*.ts'].expires).toBe(
-      '2192-12-24'
-    );
+    const exclude2 = policy.exclude?.['global'][1];
+    expect(exclude2).toBeDefined();
+    expect(exclude2).not.toBeTypeOf('string');
 
-    expect(policy.exclude['global'][1]['./deps/*.ts'].reason).toBe(
-      'it will never happen'
-    );
+    if (exclude2 && typeof exclude2 !== 'string') {
+      expect(exclude2['./deps/*.ts'].expires).toBe('2192-12-24');
+      expect(exclude2['./deps/*.ts'].reason).toBe('it will never happen');
+    }
   }).does.not.toThrow();
 });

--- a/test/unit/filter-ignore.test.ts
+++ b/test/unit/filter-ignore.test.ts
@@ -3,10 +3,15 @@ import { expect, test } from 'vitest';
 
 import * as policy from '../../lib';
 import ignore from '../../lib/filter/ignore';
-import { VulnerabilityReport } from '../../lib/types';
+import {
+  FilteredRule,
+  FilteredVulnerability,
+  FilteredVulnerabilityReport,
+  VulnerabilityReport,
+} from '../../lib/types';
 
 const fixtures = __dirname + '/../fixtures/ignore';
-const vulns = require(fixtures + '/vulns.json');
+const vulns = require(fixtures + '/vulns.json') as FilteredVulnerabilityReport;
 
 test('ignored vulns do not turn up in tests', async () => {
   const config = await policy.load(fixtures);
@@ -14,7 +19,7 @@ test('ignored vulns do not turn up in tests', async () => {
   const start = vulns.vulnerabilities.length;
   expect(vulns.vulnerabilities).length.greaterThan(0);
 
-  const filtered = [];
+  const filtered = [] as FilteredVulnerability[];
 
   vulns.vulnerabilities = ignore(
     config.ignore,
@@ -62,28 +67,32 @@ test('ignored vulns do not turn up in tests', async () => {
       },
     ],
   };
-  const actual = filtered.reduce((actual, vuln: any) => {
-    actual[vuln.id] = vuln.filtered.ignored;
-    return actual;
-  }, {});
+  const actual = filtered.reduce(
+    (actual, vuln) => {
+      actual[vuln.id] = vuln.filtered?.ignored ?? [];
+      return actual;
+    },
+    {} as {
+      [x: string]: FilteredRule[];
+    }
+  );
   expect(actual).toStrictEqual(expected);
 
-  expect(
-    vulns.vulnerabilities.every((vuln) => {
-      return !!vuln.ignored;
-    })
-  ).toBe(true);
+  expect(vulns.vulnerabilities.every((vuln) => !!vuln.filtered?.ignored)).toBe(
+    true
+  );
 });
 
 test('vulns filtered by security policy ignores', () => {
   const fixturesSecPolicy = __dirname + '/../fixtures/ignore-security-policy';
-  const vulns = require(fixturesSecPolicy + '/vulns.json');
+  const vulns = require(fixturesSecPolicy +
+    '/vulns.json') as VulnerabilityReport;
 
   policy.load(fixtures).then(() => {
     const start = vulns.vulnerabilities.length;
     expect(start).toBeGreaterThan(0);
 
-    const filtered = [];
+    const filtered = [] as FilteredVulnerability[];
 
     vulns.vulnerabilities = ignore({}, vulns.vulnerabilities, filtered);
 
@@ -107,10 +116,10 @@ test('vulns filtered by security policy ignores', () => {
       ],
     };
 
-    const actual = filtered.reduce((actual, vuln: any) => {
-      actual[vuln.id] = vuln.filtered.ignored;
+    const actual = filtered.reduce((actual, vuln) => {
+      actual[vuln.id] = vuln.filtered?.ignored;
       return actual;
-    }, {});
+    }, {} as Record<string, FilteredRule[] | undefined>);
 
     expect(actual).toStrictEqual(expected);
   });
@@ -118,14 +127,15 @@ test('vulns filtered by security policy ignores', () => {
 
 test('vulns filtered by security policy and config ignores', async () => {
   const fixturesSecPolicy = __dirname + '/../fixtures/ignore-security-policy';
-  const vulns = require(fixturesSecPolicy + '/vulns-security-metadata.json');
+  const vulns = require(fixturesSecPolicy +
+    '/vulns-security-metadata.json') as VulnerabilityReport;
 
   const config = await policy.load(fixtures);
 
   const start = vulns.vulnerabilities.length;
   expect(start).toBeGreaterThan(0);
 
-  const filtered = [];
+  const filtered = [] as FilteredVulnerability[];
 
   vulns.vulnerabilities = ignore(
     config.ignore,
@@ -181,10 +191,10 @@ test('vulns filtered by security policy and config ignores', async () => {
     ],
   };
 
-  const actual = filtered.reduce((actual, vuln: any) => {
-    actual[vuln.id] = vuln.filtered.ignored;
+  const actual = filtered.reduce((actual, vuln) => {
+    actual[vuln.id] = vuln.filtered?.ignored;
     return actual;
-  }, {});
+  }, {} as Record<string, FilteredRule[] | undefined>);
 
   expect(actual).toStrictEqual(expected);
 });
@@ -192,14 +202,14 @@ test('vulns filtered by security policy and config ignores', async () => {
 test('does not accept incomplete security policy to ignore vulns', async () => {
   const fixturesSecPolicy = __dirname + '/../fixtures/ignore-security-policy';
   const vulns = require(fixturesSecPolicy +
-    '/vulns-incomplete-security-metadata.json');
+    '/vulns-incomplete-security-metadata.json') as VulnerabilityReport;
 
   const config = await policy.load(fixtures);
 
   const start = vulns.vulnerabilities.length;
   expect(vulns.vulnerabilities).length.greaterThan(0);
 
-  const filtered = [];
+  const filtered = [] as FilteredVulnerability[];
 
   vulns.vulnerabilities = ignore(
     config.ignore,

--- a/test/unit/filter-notes.test.ts
+++ b/test/unit/filter-notes.test.ts
@@ -1,10 +1,12 @@
 import { expect, test } from 'vitest';
 
-const fixtures = __dirname + '/../fixtures';
-const vulns = require(fixtures + '/patch/vulns.json');
-
+import { FilteredVulnerabilityReport } from '../types';
 import * as policy from '../../lib';
 import notes from '../../lib/filter/notes';
+
+const fixtures = __dirname + '/../fixtures';
+const vulns = require(fixtures +
+  '/patch/vulns.json') as FilteredVulnerabilityReport;
 
 test('ignored vulns do not turn up in tests', async () => {
   const res = await policy.load([
@@ -24,7 +26,5 @@ test('ignored vulns do not turn up in tests', async () => {
   const items = vulns.vulnerabilities.map((e) => e.note).filter(Boolean);
 
   expect(items).toHaveLength(1);
-
-  expect(items[0]).toMatch(new RegExp(vulns.name));
   expect(items[0]).not.toMatch(new RegExp('undefined'));
 });

--- a/test/unit/filter-patch.test.ts
+++ b/test/unit/filter-patch.test.ts
@@ -1,11 +1,17 @@
 import fs from 'fs';
 import resolve from 'snyk-resolve';
 import { afterEach, expect, test, vi } from 'vitest';
+
 import * as policy from '../../lib';
 import patch from '../../lib/filter/patch';
+import {
+  FilteredRule,
+  FilteredVulnerability,
+  VulnerabilityReport,
+} from '../types';
 
 const fixtures = __dirname + '/../fixtures/patch';
-const vulns = require(fixtures + '/vulns.json');
+const vulns = require(fixtures + '/vulns.json') as VulnerabilityReport;
 
 afterEach(() => {
   vi.resetAllMocks();
@@ -20,7 +26,7 @@ test('patched vulns do not turn up in tests', async () => {
   const start = vulns.vulnerabilities.length;
   expect(vulns.vulnerabilities).length.greaterThan(0);
 
-  const filtered = [];
+  const filtered = [] as FilteredVulnerability[];
 
   vulns.vulnerabilities = patch(
     config.patch,
@@ -51,10 +57,10 @@ test('patched vulns do not turn up in tests', async () => {
     'npm:semver:20150403': [{ path: ['*'] }],
   };
 
-  const actual = filtered.reduce((actual, vuln: any) => {
-    actual[vuln.id] = vuln.filtered.patches;
+  const actual = filtered.reduce((actual, vuln) => {
+    actual[vuln.id] = vuln.filtered?.patches;
     return actual;
-  }, {});
+  }, {} as Record<string, FilteredRule[] | undefined>);
 
   expect(actual).toStrictEqual(expected);
   expect(vulns.vulnerabilities.every((vuln) => !!vuln.patches)).toBe(true);

--- a/test/unit/get-by-vuln.test.ts
+++ b/test/unit/get-by-vuln.test.ts
@@ -1,10 +1,12 @@
 import { promises as fs } from 'fs';
 import { expect, test } from 'vitest';
+
 import { getByVuln, loadFromText } from '../../lib';
+import { Policy, VulnerabilityReport } from '../types';
 
 const fixtures = __dirname + '/../fixtures';
-const policy = require(fixtures + '/ignore/parsed.json');
-const vulns = require(fixtures + '/ignore/vulns.json');
+const policy = require(fixtures + '/ignore/parsed.json') as Policy;
+const vulns = require(fixtures + '/ignore/vulns.json') as VulnerabilityReport;
 
 test('getByVuln (no args)', () => {
   const res = getByVuln();
@@ -19,6 +21,11 @@ test('getByVuln (no vulns)', () => {
 test('getByVuln', () => {
   const res = vulns.vulnerabilities.map(getByVuln.bind(null, policy));
   res.forEach((res, i) => {
+    expect(res).not.toBeNull();
+    if (res === null) {
+      return;
+    }
+
     expect(res.type).toBe('ignore');
     expect(res.id).toBe(vulns.vulnerabilities[i].id);
   });
@@ -36,8 +43,12 @@ test('getByVuln with star rules', async () => {
   const policy = await loadFromText(file);
   const res = getByVuln(policy, vuln);
 
-  expect(res.id).toBe(id);
-  expect(res.rule).not.empty;
+  expect(res).not.toBeNull();
+
+  if (res !== null) {
+    expect(res.id).toBe(id);
+    expect(res.rule).not.empty;
+  }
 });
 
 test('getByVuln with exact match rules', async () => {
@@ -48,6 +59,10 @@ test('getByVuln with exact match rules', async () => {
   const policy = await loadFromText(file);
   const res = getByVuln(policy, vuln);
 
-  expect(res.id).toBe(id);
-  expect(res.rule).not.empty;
+  expect(res).not.toBeNull();
+
+  if (res !== null) {
+    expect(res.id).toBe(id);
+    expect(res.rule).not.empty;
+  }
 });

--- a/test/unit/helpers.ts
+++ b/test/unit/helpers.ts
@@ -1,0 +1,14 @@
+/**
+ * Strips functions from an object
+ * @param obj (*mutates!*) the object from which to strip functions
+ */
+export function stripFunctions<T>(obj: T) {
+  // strip functions (as they don't land in the final config)
+  for (const key in obj) {
+    if (typeof obj[key] === 'function') {
+      delete obj[key];
+    }
+  }
+
+  return obj;
+}

--- a/test/unit/match.test.ts
+++ b/test/unit/match.test.ts
@@ -1,7 +1,8 @@
 import fs from 'fs';
 import { describe, expect, test } from 'vitest';
+
 import * as policy from '../../lib';
-import { PathObj, Rule, RuleSet, Vulnerability } from '../../lib/types';
+import { Rule, Vulnerability } from '../types';
 
 const fixtures = __dirname + '/../fixtures';
 

--- a/test/unit/policy-args.test.ts
+++ b/test/unit/policy-args.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, expect, test, vi } from 'vitest';
+
 import * as policy from '../../lib';
+import { stripFunctions } from './helpers';
 
 const fixtures = __dirname + '/../fixtures';
 
@@ -45,14 +47,3 @@ test('policy loads without args - non simple', async () => {
   const res = await policy.load();
   expect(Object.keys(res.ignore)).not.toBe(0);
 });
-
-function stripFunctions(res: object) {
-  // strip functions (as they don't land in the final config)
-  Object.keys(res).forEach((key) => {
-    if (typeof res[key] === 'function') {
-      delete res[key];
-    }
-  });
-
-  return res;
-}

--- a/test/unit/policy-parse.test.ts
+++ b/test/unit/policy-parse.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from 'vitest';
+
 import * as policy from '../../lib';
+import { Rule } from '../types';
 
 const fixtures = __dirname + '/../fixtures/issues/SC-1106/';
 const withoutDash = fixtures + '/missing-dash.snyk';
@@ -21,7 +23,7 @@ test('missing dash on policy is fixed up', () => {
   });
 });
 
-function getPaths(rules) {
+function getPaths(rules: Rule[]) {
   return rules
     .map((rule) => {
       const keys = Object.keys(rule);

--- a/test/unit/types.test.ts
+++ b/test/unit/types.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 
-import { isObject } from 'lib/types';
+import { isObject } from '../../lib/types';
 
 test('isObject', () => {
   // Testing for objects

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -82,9 +82,9 @@
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
 
     /* Type Checking */
-    "strict": false,                                     /* Enable all strict type-checking options. */
-    "noImplicitAny": false,                              /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    "strictNullChecks": false,                           /* When type checking, take into account 'null' and 'undefined'. */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": false,                           /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */


### PR DESCRIPTION
#### What does this PR do?

Types all of the test files and turns strict type checking on. This PR should not change any logic

#### What are the relevant tickets?

[NARW-2131](https://snyksec.atlassian.net/browse/NARW-2131)

[NARW-2131]: https://snyksec.atlassian.net/browse/NARW-2131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ