### PR TITLE
fix: handle empty rules

### DIFF
--- a/lib/parser/v1.ts
+++ b/lib/parser/v1.ts
@@ -82,6 +82,18 @@ function checkForOldFormat(ruleSet: unknown) {
  * @param ruleSet (*mutates!*) the rule set to validate
  */
 function validate(ruleSet: RuleSet) {
+  // replace nulls with empty arrays and empty rules with empty objects
+  for (const [id, pathObjs] of Object.entries(ruleSet)) {
+    // default ruleset entries to []
+    ruleSet[id] = pathObjs ?? [] as PathObj[];
+    for (const pathObj of ruleSet[id]) {
+      for (const path in pathObj) {
+        // default empty rules to {}
+        pathObj[path] = pathObj[path] ?? {} as Rule;
+      }
+    }
+  }
+
   const fix = needsFixing(ruleSet);
 
   if (fix) {

--- a/test/unit/filter-empty-rule.test.ts
+++ b/test/unit/filter-empty-rule.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from 'vitest';
+
+import * as policy from '../../lib';
+import { Vulnerability } from 'lib/types';
+
+const vulnReport = { 
+  ok: false, 
+  vulnerabilities: [{
+    id: "SNYK-CC-K8S-44", 
+      from: [
+        "infrastructure/iac/testdata/RBAC-copy.yaml"
+      ],
+    } as Vulnerability
+  ]
+}
+
+test('empty ignore ruleset does not error', async () => {
+  const config = await policy.loadFromText(`ignore:`);
+      
+  const vulns = config.filter({...vulnReport});
+      
+  expect(vulns.ok).toBe(false);
+});
+
+test('empty ignore pathObj does not error', async () => {
+  const config = await policy.loadFromText(
+    `ignore:
+      SNYK-CC-K8S-44:
+    `);
+
+    const vulns = config.filter({...vulnReport});
+
+    expect(vulns.ok).toBe(false);
+});
+
+test('empty ignore rule ignores matching vulnerability', async () => {
+  const config = await policy.loadFromText(
+    `ignore:
+      SNYK-CC-K8S-44:
+      - 'infrastructure/iac/testdata/RBAC-copy.yaml > [DocId: 1] > clusterrole > rules[0] > verbs':
+    `);
+
+  const vulns = config.filter({...vulnReport});
+
+  expect(vulns.ok).toBe(true);
+});
+
+test('empty patch ruleset does not error', async () => {
+  const config = await policy.loadFromText(`ignore:`);
+
+  const vulns = config.filter({...vulnReport});
+
+  expect(vulns.ok).toBe(false);
+});
+
+test('empty patch pathObj does not error', async () => {
+  const config = await policy.loadFromText(
+    `patch:
+      SNYK-CC-K8S-44:
+    `);
+
+  const vulns = config.filter({...vulnReport});
+        
+  expect(vulns.ok).toBe(false);
+});
+
+test('empty patch rule does not error', async () => {
+  const config = await policy.loadFromText(
+    `patch:
+      SNYK-CC-K8S-44:
+      - 'infrastructure/iac/testdata/RBAC-copy.yaml > [DocId: 1] > clusterrole > rules[0] > verbs':
+    `);
+
+  const vulns = config.filter({...vulnReport});
+  
+  expect(vulns.ok).toBe(false);
+});


### PR DESCRIPTION
#### What does this PR do?

`policy.filter` no longer throws an error when the policy file contains empty rulesets, path objects or rules for both `ignore` and `patch` as shown below. In these cases, the policy file will now default to `{}` or `[]` internally.

**Missing Ruleset**
- results in an empty rule set with no path objects
```
ignore:
```

**Missing Path Object**
- results in an empty path object with no rules
```
ignore:
      SNYK-CC-K8S-44:
```

**Missing Rule**
- all fields are optional, so this is a valid rule
```
ignore:
      SNYK-CC-K8S-44:
      - 'infrastructure/iac/testdata/RBAC-copy.yaml > [DocId: 1] > clusterrole > rules[0] > verbs':
```
