### PR TITLE
fix: check for old alpha `.snyk` file format and throw

### DIFF
--- a/lib/parser/v1.ts
+++ b/lib/parser/v1.ts
@@ -67,11 +67,11 @@ function checkForOldFormat(ruleSet: unknown) {
   // alpha format, and we'll throw
   if (isObject(ruleSet)) {
     for (const id in ruleSet) {
-      if (!Array.isArray(ruleSet[id])) {
+      if (ruleSet[id] && !Array.isArray(ruleSet[id])) {
         // create an error and add a code field to it without using `any`
-        // const error = new Error('old, unsupported .snyk format detected');
-        // error.code = 'OLD_DOTFILE_FORMAT';
-        // throw error;
+        const error: NodeJS.ErrnoException = new Error('old, unsupported .snyk format detected');
+        error.code = 'OLD_DOTFILE_FORMAT';
+        throw error;
       }
     }
   }

--- a/test/unit/old-format.test.ts
+++ b/test/unit/old-format.test.ts
@@ -1,12 +1,9 @@
 import { expect, test } from 'vitest';
 import * as policy from '../../lib';
 
-test('test sensibly bails if gets an old .snyk format', () => {
-  expect(() =>
-    policy.load(__dirname + '/../fixtures/old-snyk-config/').catch((e) => {
-      expect(e.message).toBe('old, unsupported .snyk format detected');
-      expect(e.code).toBe('OLD_DOTFILE_FORMAT');
-      throw e;
-    })
-  ).rejects.toThrow();
+test('test sensibly bails if gets an old .snyk format', async () => {
+  const oldSnykFormatError: NodeJS.ErrnoException = new Error('old, unsupported .snyk format detected');
+  oldSnykFormatError.code = 'OLD_DOTFILE_FORMAT';
+
+  await expect(() => policy.load(__dirname + '/../fixtures/old-snyk-config/')).rejects.toThrow(oldSnykFormatError);
 });


### PR DESCRIPTION
#### What does this PR do?

Re-enables throwing of errors when an early alpha format of the `.snyk` file is found. This was temporarily commented out during the switch to Typescript, but was not re-enabled.
