### PR TITLE
chore: type filter to reflect mutation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .dccache
 .envrc
+.DS_Store
 /.nyc_output/
 /node_modules/
 /coverage

--- a/lib/filter/notes.ts
+++ b/lib/filter/notes.ts
@@ -52,7 +52,7 @@ function attachNotes<T extends Vulnerability>(notes: RuleSet, vuln: T[]) {
           if (
             pathMatch &&
             rule[path].disregardIfFixable &&
-            (vuln.upgradePath.length || vuln.patches.length)
+            (vuln.upgradePath?.length || vuln.patches?.length)
           ) {
             debug(
               '%s vuln is fixable and rule is set to disregard if fixable',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -47,7 +47,7 @@ export interface FilteredVulnerabilityReport<T extends Vulnerability = Vulnerabi
 
   vulnerabilities: FilteredVulnerability<T>[];
 
-  filtered?: {
+  filtered: {
     ignore: Vulnerability[];
     patch: Vulnerability[];
   };
@@ -143,11 +143,11 @@ export interface Policy {
   addIgnore: (options: AddRuleOptions) => Policy;
   addPatch: (options: AddRuleOptions) => Policy;
   demunge: (apiRoot?: string) => DemungedResults;
-  filter: <T extends Vulnerability = Vulnerability>(
-    vulns: VulnerabilityReport<T>,
+  filter: <VulnType extends Vulnerability, ReportType>(
+    vulns: ReportType & VulnerabilityReport<VulnType>,
     root?: string,
     matchStrategy?: MatchStrategy
-  ) => FilteredVulnerabilityReport<T>;
+  ) => ReportType & FilteredVulnerabilityReport<VulnType>;
   save: (root?: string | undefined, spinner?: Spinner) => Promise<void>;
 }
 
@@ -224,7 +224,7 @@ export type Spinner = {
 export interface Vulnerability {
   __filename?: string;
   readonly id: string;
-  severity: Severity;
+  severity?: Severity;
 
   /**
    * The dependency path in which the vulnerability was introduced. A chain of the packages leading
@@ -235,18 +235,18 @@ export interface Vulnerability {
    */
   from: string[];
 
-  isUpgradable: boolean;
+  isUpgradable?: boolean;
 
   /**
    * A possible upgrade remediation path. Mirrors the `from` field above, but contains upgraded
    * versions. The element [0] is usually `false` and is of no use.  If the element [1] is false,
    * there's no valid complete upgrade path yet.
    */
-  upgradePath: (string | boolean)[];
+  upgradePath?: (string | boolean)[];
 
-  isPatchable: boolean;
+  isPatchable?: boolean;
 
-  patches: Patch[];
+  patches?: Patch[];
 
   securityPolicyMetaData?: SecurityPolicyMetaData;
 }


### PR DESCRIPTION
#### What does this PR do?

The vulnerability object is mutated when filtering, so this PR update the vulns type and the return type to take this into account.

After reviewing policy lib usage in the Snyk CLI, isUpgradable, upgradePath, isPatchable and patches have also been made optional
