### PR TITLE
Fix/ignr 245 fix broken license issue url

### DIFF
--- a/lib/parser/demunge.ts
+++ b/lib/parser/demunge.ts
@@ -1,4 +1,5 @@
 import {
+  ApiRootFunction,
   DemungedResults,
   PathObj,
   PathRule,
@@ -11,10 +12,10 @@ export default demunge;
 /**
  * Demunges the given policy object.
  * @param policy  The policy object to demunge
- * @param apiRoot The root URL of the Snyk API
+ * @param apiRoot A string or func calculating the base URL for the Snyk API
  * @returns The demunged policy object
  */
-function demunge(policy: Policy, apiRoot = '') {
+function demunge(policy: Policy, apiRoot?: ApiRootFunction | string) {
   const res = (
     ['ignore', 'patch', 'exclude'] as ('ignore' | 'patch' | 'exclude')[]
   ).reduce((acc, type) => {
@@ -46,9 +47,10 @@ function demunge(policy: Policy, apiRoot = '') {
               return res;
             },
           );
+
           return {
             id: id,
-            url: apiRoot + '/vuln/' + id,
+            url: getBaseUrl(id, apiRoot) + '/vuln/' + id,
             paths: paths,
           } as VulnRules;
         })
@@ -59,4 +61,14 @@ function demunge(policy: Policy, apiRoot = '') {
   res.version = policy.version;
 
   return res;
+}
+
+function getBaseUrl(
+  vulnId: string,
+  apiRoot?: ApiRootFunction | string,
+): string {
+  if (apiRoot == undefined) {
+    return '';
+  }
+  return typeof apiRoot === 'function' ? apiRoot(vulnId) : apiRoot;
 }

--- a/lib/policy.ts
+++ b/lib/policy.ts
@@ -8,7 +8,13 @@ import add from './add';
 import addExclude from './add-exclude';
 import filter from './filter';
 import * as parse from './parser';
-import { PathObj, Policy, Spinner, isNodeError } from './types';
+import {
+  PathObj,
+  Policy,
+  Spinner,
+  isNodeError,
+  ApiRootFunction,
+} from './types';
 
 export { demunge } from './parser';
 export { getByVuln, matchToRule } from './match';
@@ -38,7 +44,8 @@ function attachMethods(policy: Pick<Policy, '__filename'> & Partial<Policy>) {
     );
   policy.save = (root, spinner) => save(policy as Policy, root, spinner);
   policy.toString = () => parse.export(policy as Policy);
-  policy.demunge = (apiRoot) => parse.demunge(policy as Policy, apiRoot);
+  policy.demunge = (apiRoot?: ApiRootFunction | string) =>
+    parse.demunge(policy as Policy, apiRoot);
   policy.add = (type: 'ignore' | 'patch', options) =>
     add(policy as Policy, type, options);
   policy.addIgnore = (options) => add(policy as Policy, 'ignore', options);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -145,7 +145,7 @@ export interface Policy {
   addExclude: (pattern: string, group?: PatternGroup, options?: Rule) => void;
   addIgnore: (options: AddRuleOptions) => Policy;
   addPatch: (options: AddRuleOptions) => Policy;
-  demunge: (apiRoot?: string) => DemungedResults;
+  demunge: (apiRoot?: ApiRootFunction | string) => DemungedResults;
   filter: <VulnType extends Vulnerability, ReportType>(
     vulns: ReportType & VulnerabilityReport<VulnType>,
     root?: string,
@@ -299,6 +299,11 @@ export interface VulnRules {
    */
   paths: PathRule[];
 }
+
+/**
+ * Type of a function returning the root of a vulnerability URL
+ */
+export type ApiRootFunction = (vulnId: string) => string;
 
 /**
  * Returns true if the value is an object. This is a more reliable check than `typeof` or

--- a/test/fixtures/parsed.json
+++ b/test/fixtures/parsed.json
@@ -17,9 +17,9 @@
   },
   "version": "v1",
   "ignore": {
-    "npm:hawk:20160119": [
+    "snyk:lic:npm:shescape:MPL-2.0": [
       {
-        "sqlite > sqlite3 > node-pre-gyp > request > hawk": {
+        "*": {
           "reason": "None given",
           "expires": "2016-03-01T14:30:04.136Z"
         }


### PR DESCRIPTION
#### What does this PR do?

⚠️  Breaking change alert! ⚠️

IGNR-245 At the moment URLs pointing at the licenses are broken pointing at https://security.snyk.io/vuln/snyk:lic:npm:kafkajs-metrics:MPL-2.0 rather than https://snyk.io/vuln/snyk:lic:npm:kafkajs-metrics:MPL-2.0.
The changes in the PR add a new config parameter to the `demunge()` function, which allows to specify a dirrefent URL root for licenses.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/IGNR-245

