### PR TITLE
fix(ignr-729): replace context with expired GH token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,8 @@ workflows:
                 - master
       - release:
           name: Release
-          context: narwhal-policy
+          context:
+            - nodejs-lib-release
           filters:
             branches:
               only:


### PR DESCRIPTION
This commit replaces narwhal-policy CI context which contained the expired GH_TOKEN with the nodejs-lib-release CI context which has an active GH token. 
