### PR TITLE
feat: add isPinnable check in handling disregardIfFixable

### DIFF
--- a/lib/filter/ignore.ts
+++ b/lib/filter/ignore.ts
@@ -111,7 +111,7 @@ function filterIgnored<T extends Vulnerability>(
                 if (
                   pathMatch &&
                   rule[path].disregardIfFixable &&
-                  (vuln.isUpgradable || vuln.isPatchable)
+                  (vuln.isUpgradable || vuln.isPatchable || vuln.isPinnable)
                 ) {
                   debug(
                     '%s vuln is fixable and rule is set to disregard if fixable',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -249,6 +249,8 @@ export interface Vulnerability {
 
   isPatchable?: boolean;
 
+  isPinnable?: boolean;
+
   patches?: Patch[];
 
   securityPolicyMetaData?: SecurityPolicyMetaData;

--- a/test/unit/filter-ignore.test.ts
+++ b/test/unit/filter-ignore.test.ts
@@ -259,6 +259,105 @@ test('filters vulnerabilities by exact match', async () => {
   expect(filtered.vulnerabilities).toStrictEqual(expected.vulnerabilities);
 });
 
+test('disregardIfFixable does not ignore pinnable-only vulns', () => {
+  const pinnableVuln = {
+    id: 'SNYK-PYTHON-PIP-13045331',
+    from: ['root@0.0.0', 'chalice@1.30.0', 'pip@23.3.2'],
+    isUpgradable: false,
+    isPatchable: false,
+    isPinnable: true,
+    upgradePath: [],
+  } as Vulnerability;
+
+  const nonFixableVuln = {
+    id: 'SNYK-PYTHON-PIP-13045331',
+    from: ['root@0.0.0', 'chalice@1.30.0', 'pip@23.3.2'],
+    isUpgradable: false,
+    isPatchable: false,
+    isPinnable: false,
+    upgradePath: [],
+  } as Vulnerability;
+
+  const ignoreRules = {
+    'SNYK-PYTHON-PIP-13045331': [
+      {
+        '*': {
+          reason: 'Fix is not currently available',
+          disregardIfFixable: true,
+        },
+      },
+    ],
+  };
+
+  const filteredPinnable = [] as FilteredVulnerability[];
+  const resultPinnable = ignore(
+    ignoreRules,
+    [pinnableVuln],
+    filteredPinnable,
+  );
+  expect(resultPinnable).toHaveLength(1);
+  expect(resultPinnable[0].id).toBe('SNYK-PYTHON-PIP-13045331');
+  expect(filteredPinnable).toHaveLength(0);
+
+  const filteredNonFixable = [] as FilteredVulnerability[];
+  const resultNonFixable = ignore(
+    ignoreRules,
+    [nonFixableVuln],
+    filteredNonFixable,
+  );
+  expect(resultNonFixable).toHaveLength(0);
+  expect(filteredNonFixable).toHaveLength(1);
+});
+
+test('disregardIfFixable still works for upgradable and patchable vulns', () => {
+  const upgradableVuln = {
+    id: 'test-vuln-1',
+    from: ['root@0.0.0', 'foo@1.0.0'],
+    isUpgradable: true,
+    isPatchable: false,
+    isPinnable: false,
+    upgradePath: [false, 'foo@2.0.0'],
+  } as Vulnerability;
+
+  const patchableVuln = {
+    id: 'test-vuln-1',
+    from: ['root@0.0.0', 'bar@1.0.0'],
+    isUpgradable: false,
+    isPatchable: true,
+    isPinnable: false,
+    upgradePath: [],
+  } as Vulnerability;
+
+  const ignoreRules = {
+    'test-vuln-1': [
+      {
+        '*': {
+          reason: 'temporary',
+          disregardIfFixable: true,
+        },
+      },
+    ],
+  };
+
+  const filteredUpgradable = [] as FilteredVulnerability[];
+  const resultUpgradable = ignore(
+    ignoreRules,
+    [upgradableVuln],
+    filteredUpgradable,
+  );
+  expect(resultUpgradable).toHaveLength(1);
+  expect(filteredUpgradable).toHaveLength(0);
+
+  const filteredPatchable = [] as FilteredVulnerability[];
+  const resultPatchable = ignore(
+    ignoreRules,
+    [patchableVuln],
+    filteredPatchable,
+  );
+  expect(resultPatchable).toHaveLength(1);
+  expect(filteredPatchable).toHaveLength(0);
+});
+
 test('vulnerabilities filter is case insensitive', async () => {
   const vulnToBeIgnored = {
     id: 'A-VULN',


### PR DESCRIPTION
BREAKING CHANGE: disregardIfFixable now treats pinnable vulnerabilities as fixable again. Pinnable-only vulnerabilities will no longer be ignored when disregardIfFixable is enabled.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
This PR releases this change (https://github.com/snyk/policy/pull/214) as a breaking change.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/IGNR-2012