### PR TITLE
feat: support secrets section in dotsnyk excludes [PS-715]

### DIFF
--- a/lib/add-exclude.ts
+++ b/lib/add-exclude.ts
@@ -39,5 +39,5 @@ function addExclude(
 }
 
 function isPatternGroupValid(group: string) {
-  return ['global', 'code', 'iac-drift'].includes(group);
+  return ['global', 'code', 'iac-drift', 'secrets'].includes(group);
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -153,7 +153,7 @@ export type PathRule = {
   reason?: string;
 };
 
-export type PatternGroup = 'global' | 'code' | 'iac-drift';
+export type PatternGroup = 'global' | 'code' | 'iac-drift' | 'secrets';
 
 export interface Policy {
   __filename: string | null;

--- a/test/unit/add-exclude.test.ts
+++ b/test/unit/add-exclude.test.ts
@@ -62,6 +62,17 @@ test('add a new file pattern to iac drift-group', async (_t) => {
   }).does.not.toThrow();
 });
 
+test('add a new file pattern to secrets-group', async (_t) => {
+  let policy = await create();
+  expect(() => {
+    const validGroup = 'secrets';
+    policy.addExclude('./deps/*.ts', validGroup);
+
+    const expected = { secrets: ['./deps/*.ts'] };
+    expect(policy.exclude).toStrictEqual(expected);
+  }).does.not.toThrow();
+});
+
 test('add two new unique file pattern to a group', async (_t) => {
   let policy = await create();
   expect(() => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adds support for a "secrets" excludes section in the .snyk file 


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

https://snyk.slack.com/archives/C073HFTPLSF/p1781013347426029

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/PS-715

#### Screenshots
before 

<img width="1436" height="157" alt="Screenshot 2026-06-18 at 17 34 43" src="https://github.com/user-attachments/assets/6b277a99-d6b3-4046-be26-e141ea362141" />

after 
<img width="875" height="40" alt="Screenshot 2026-06-18 at 17 35 05" src="https://github.com/user-attachments/assets/896db0a6-6fd2-4631-8884-8eb3a3077fec" />

#### Additional questions
