### PR TITLE
fix(deps): [IGNR-2173] bump js-yaml to ^3.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "email-validator": "^2.0.4",
-    "js-yaml": "^3.14.2",
+    "js-yaml": "^3.15.0",
     "lodash": "^4.18.1",
     "lodash.clonedeep": "^4.5.0",
     "lru-cache": "^4.1.5",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Raises the `js-yaml` dependency floor to `^3.15.0`.

#### What are the relevant tickets?

IGNR-2173

#### Screenshots

#### Additional questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
