### PR TITLE
chore: rename owning team to appsec_guardrails

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @snyk/platform-experience_guardrails
+* @snyk/appsec_guardrails
 
 lib/add-exclude.js @snyk/tundra


### PR DESCRIPTION
## Summary
The GitHub team `platform-experience_guardrails` was renamed to `appsec_guardrails`. This PR updates `.github/CODEOWNERS` to reference the new team slug so ownership continues to resolve correctly. This is a pure text rename — no ownership changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only team slug and catalog owner renames with no application or runtime behavior changes.
> 
> **Overview**
> Updates repository ownership metadata to match the renamed GitHub team **`appsec_guardrails`**.
> 
> **`.github/CODEOWNERS`** now assigns default review ownership to `@snyk/appsec_guardrails` instead of `@snyk/platform-experience_guardrails`. **`catalog-info.yaml`** updates the Backstage `github.com/team-slug` annotation and `spec.owner` from `ignores` to `appsec_guardrails` so catalog ownership stays aligned with GitHub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1d243e9e3c6d57659af886c737d537f493f844c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Jira

[IGNR-2339: Migrate repository ownership to appsec_guardrails](https://snyksec.atlassian.net/browse/IGNR-2339)


### Catalog ownership

Updates `inventory` and `ignores` catalog owners and matching GitHub team annotations to `appsec_guardrails`, verified to exist in [Roadie](https://snyk.roadie.so/catalog/default/group/appsec_guardrails). Other owners and API definitions are preserved. YAML parsing, ownership-only structural comparison, and `git diff --check` passed.
